### PR TITLE
Simplify auth layouts for cleaner forms

### DIFF
--- a/app/forgot-password/forgot-password-card.tsx
+++ b/app/forgot-password/forgot-password-card.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, CheckCircle2, Loader2, Mail } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export function ForgotPasswordCard() {
+  const [email, setEmail] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsLoading(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    console.log("Password reset request for:", email);
+    setIsLoading(false);
+    setIsSubmitted(true);
+  };
+
+  if (isSubmitted) {
+    return (
+      <Card className="border border-white/10 bg-background/95 shadow-lg">
+        <CardHeader className="space-y-2 text-center">
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-emerald-500/15">
+            <CheckCircle2 className="h-7 w-7 text-emerald-400" />
+          </div>
+          <CardTitle className="text-2xl font-semibold">Check your email</CardTitle>
+          <CardDescription>
+            We sent a reset link to <span className="font-medium text-slate-100">{email}</span>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="text-center text-sm text-muted-foreground">
+          If it doesn't arrive soon, check your spam folder or resend the email.
+        </CardContent>
+        <CardFooter className="flex flex-col gap-3 sm:flex-row">
+          <Button
+            variant="outline"
+            className="w-full"
+            asChild
+          >
+            <Link href="/login" className="inline-flex items-center justify-center gap-2">
+              <ArrowLeft className="h-4 w-4" />
+              Back to login
+            </Link>
+          </Button>
+          <Button
+            className="w-full bg-gradient-to-r from-primary to-primary/80 text-white hover:from-primary/90 hover:to-primary"
+            onClick={() => setIsSubmitted(false)}
+          >
+            Resend email
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="border border-white/10 bg-background/95 shadow-lg">
+      <CardHeader className="space-y-2 text-center">
+        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+          <Mail className="h-6 w-6 text-primary" />
+        </div>
+        <CardTitle className="text-2xl font-semibold">Reset password</CardTitle>
+        <CardDescription>Enter your email address to receive a reset link.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="email">Email address</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="you@example.com"
+              required
+            />
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full bg-gradient-to-r from-primary to-primary/80 text-white shadow-md transition hover:from-primary/90 hover:to-primary"
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Sending reset link
+              </span>
+            ) : (
+              "Send reset link"
+            )}
+          </Button>
+        </form>
+      </CardContent>
+      <CardFooter>
+        <p className="w-full text-center text-sm text-muted-foreground">
+          Remembered your password?{" "}
+          <Link href="/login" className="font-medium text-primary hover:text-primary/80">
+            Go back to sign in
+          </Link>
+        </p>
+      </CardFooter>
+    </Card>
+  );
+}
+
+export default ForgotPasswordCard;

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,119 +1,17 @@
-"use client"
+import type React from "react";
 
-import type React from "react"
+import { AuthPageLayout } from "@/components/auth-page-layout";
 
-import { useState } from "react"
-import Link from "next/link"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { ArrowLeft, Mail } from "lucide-react"
+import { ForgotPasswordCard } from "./forgot-password-card";
 
-export default function ForgotPasswordPage() {
-  const [email, setEmail] = useState("")
-  const [isLoading, setIsLoading] = useState(false)
-  const [isSubmitted, setIsSubmitted] = useState(false)
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setIsLoading(true)
-
-    // Simulate API call
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-
-    console.log("Password reset request for:", email)
-    setIsLoading(false)
-    setIsSubmitted(true)
-  }
-
-  if (isSubmitted) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background to-muted/50 p-4">
-        <div className="w-full max-w-md">
-          <Card>
-            <CardHeader className="text-center">
-              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
-                <Mail className="h-6 w-6 text-green-600" />
-              </div>
-              <CardTitle>Check your email</CardTitle>
-              <CardDescription>We've sent a password reset link to {email}</CardDescription>
-            </CardHeader>
-            <CardContent className="text-center space-y-4">
-              <p className="text-sm text-muted-foreground">
-                Didn't receive the email? Check your spam folder or{" "}
-                <button onClick={() => setIsSubmitted(false)} className="text-primary hover:underline">
-                  try again
-                </button>
-              </p>
-            </CardContent>
-            <CardFooter>
-              <Link href="/login" className="w-full">
-                <Button variant="outline" className="w-full">
-                  <ArrowLeft className="mr-2 h-4 w-4" />
-                  Back to login
-                </Button>
-              </Link>
-            </CardFooter>
-          </Card>
-        </div>
-      </div>
-    )
-  }
-
+export default function ForgotPasswordPage(): React.ReactElement {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background to-muted/50 p-4">
-      <div className="w-full max-w-md">
-        {/* Logo and Header */}
-        <div className="text-center mb-8">
-          <Link href="/" className="inline-flex items-center gap-2 mb-4">
-            <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path
-                d="M8 6C8 4.89543 8.89543 4 10 4H22C23.1046 4 24 4.89543 24 6V26C24 27.1046 23.1046 28 22 28H10C8.89543 28 8 27.1046 8 26V6Z"
-                fill="#FF5722"
-              />
-              <path d="M14 10L18 14M18 10L14 14" stroke="#0D47A1" strokeWidth="2" strokeLinecap="round" />
-              <path d="M14 18L18 22M18 18L14 22" stroke="#0D47A1" strokeWidth="2" strokeLinecap="round" />
-            </svg>
-            <span className="text-2xl font-bold text-primary">CodeJoin</span>
-          </Link>
-          <h1 className="text-2xl font-bold">Forgot your password?</h1>
-          <p className="text-muted-foreground">No worries, we'll send you reset instructions</p>
-        </div>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Reset password</CardTitle>
-            <CardDescription>Enter your email address and we'll send you a link to reset your password</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="email">Email</Label>
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="Enter your email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                />
-              </div>
-              <Button type="submit" className="w-full" disabled={isLoading}>
-                {isLoading ? "Sending..." : "Send reset link"}
-              </Button>
-            </form>
-          </CardContent>
-          <CardFooter>
-            <Link href="/login" className="w-full">
-              <Button variant="outline" className="w-full">
-                <ArrowLeft className="mr-2 h-4 w-4" />
-                Back to login
-              </Button>
-            </Link>
-          </CardFooter>
-        </Card>
-      </div>
-    </div>
-  )
+    <AuthPageLayout
+      eyebrow="Reset access"
+      title="Forgot your password?"
+      description="Send yourself a reset link and pick a new password."
+    >
+      <ForgotPasswordCard />
+    </AuthPageLayout>
+  );
 }

--- a/app/login/login-card.tsx
+++ b/app/login/login-card.tsx
@@ -15,7 +15,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-import { Eye, EyeOff } from "lucide-react";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
 import { LoginGoogle } from "@/components/login-google";
 import { LoginGithub } from "@/components/login-github";
 import { useRouter } from "next/navigation";
@@ -58,33 +58,35 @@ export default function LoginCard() {
   };
 
   return (
-    <Card>
-      <CardHeader className="space-y-1">
-        <CardTitle className="text-2xl text-center">Sign in</CardTitle>
-        <CardDescription className="text-center">
-          Enter your email and password to access your account
-        </CardDescription>
+    <Card className="border border-white/10 bg-background/95 shadow-lg">
+      <CardHeader className="space-y-2 text-center">
+        <CardTitle className="text-2xl font-semibold">Sign in</CardTitle>
+        <CardDescription>Continue with email or a connected provider.</CardDescription>
       </CardHeader>
-      <CardContent className="space-y-4">
+      <CardContent className="space-y-6">
         {/* Social Logins */}
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-3">
           <LoginGithub />
           <LoginGoogle />
         </div>
 
         <div className="relative">
           <div className="absolute inset-0 flex items-center">
-            <Separator className="w-full" />
+            <Separator className="w-full bg-white/10" />
           </div>
           <div className="relative flex justify-center text-xs uppercase">
-            <span className="bg-background px-2 text-muted-foreground">
-              Or continue with
+            <span className="rounded-full bg-background px-3 py-1 text-muted-foreground">
+              Or continue with email
             </span>
           </div>
         </div>
 
         {/* Show error if any */}
-        {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+        {error && (
+          <div className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+            {error}
+          </div>
+        )}
 
         {/* Login Form */}
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -94,7 +96,7 @@ export default function LoginCard() {
               id="email"
               name="email"
               type="email"
-              placeholder="Enter your email"
+              placeholder="name@company.com"
               value={formData.email}
               onChange={handleInputChange}
               required
@@ -102,11 +104,13 @@ export default function LoginCard() {
           </div>
 
           <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <Label htmlFor="password">Password</Label>
+            <div className="flex items-center justify-between text-sm">
+              <Label htmlFor="password" className="text-sm">
+                Password
+              </Label>
               <Link
                 href="/forgot-password"
-                className="text-sm text-primary hover:underline"
+                className="font-medium text-primary transition hover:text-primary/80"
               >
                 Forgot password?
               </Link>
@@ -116,7 +120,7 @@ export default function LoginCard() {
                 id="password"
                 name="password"
                 type={showPassword ? "text" : "password"}
-                placeholder="Enter your password"
+                placeholder="••••••••"
                 value={formData.password}
                 onChange={handleInputChange}
                 required
@@ -125,7 +129,7 @@ export default function LoginCard() {
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                className="absolute right-0 top-0 h-full px-3 py-2 text-muted-foreground hover:bg-transparent"
                 onClick={() => setShowPassword(!showPassword)}
               >
                 {showPassword ? (
@@ -137,19 +141,30 @@ export default function LoginCard() {
             </div>
           </div>
 
-          <Button type="submit" className="w-full" disabled={isLoading}>
-            {isLoading ? "Signing in..." : "Sign in"}
+          <Button
+            type="submit"
+            className="w-full bg-gradient-to-r from-primary to-primary/80 text-white shadow-md transition hover:from-primary/90 hover:to-primary"
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Signing in
+              </span>
+            ) : (
+              "Sign in"
+            )}
           </Button>
         </form>
       </CardContent>
       <CardFooter>
-        <p className="text-center text-sm text-muted-foreground w-full">
+        <p className="w-full text-center text-sm text-muted-foreground">
           Don't have an account?{" "}
           <Link
             href="/signup"
-            className="text-primary hover:underline font-medium"
+            className="font-medium text-primary transition hover:text-primary/80"
           >
-            Sign up
+            Create one now
           </Link>
         </p>
       </CardFooter>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,60 +1,31 @@
 import type React from "react";
+
 import Link from "next/link";
+
+import { AuthPageLayout } from "@/components/auth-page-layout";
+
 import LoginCard from "./login-card";
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background to-muted/50 p-4">
-      <div className="w-full max-w-md">
-        {/* Logo and Header */}
-        <div className="text-center mb-8">
-          <Link href="/" className="inline-flex items-center gap-2 mb-4">
-            <svg
-              width="32"
-              height="32"
-              viewBox="0 0 32 32"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8 6C8 4.89543 8.89543 4 10 4H22C23.1046 4 24 4.89543 24 6V26C24 27.1046 23.1046 28 22 28H10C8.89543 28 8 27.1046 8 26V6Z"
-                fill="#FF5722"
-              />
-              <path
-                d="M14 10L18 14M18 10L14 14"
-                stroke="#0D47A1"
-                strokeWidth="2"
-                strokeLinecap="round"
-              />
-              <path
-                d="M14 18L18 22M18 18L14 22"
-                stroke="#0D47A1"
-                strokeWidth="2"
-                strokeLinecap="round"
-              />
-            </svg>
-            <span className="text-2xl font-bold text-primary">CodeJoin</span>
-          </Link>
-          <h1 className="text-2xl font-bold">Welcome back</h1>
-          <p className="text-muted-foreground">
-            Sign in to your account to continue
-          </p>
-        </div>
-
-        <LoginCard />
-
-        {/* Footer */}
-        <p className="text-center text-xs text-muted-foreground mt-8">
+    <AuthPageLayout
+      eyebrow="Welcome back"
+      title="Sign in to CodeJoin"
+      description="Use your email or a connected provider to continue."
+      footer={
+        <>
           By signing in, you agree to our{" "}
-          <Link href="/terms" className="hover:underline">
+          <Link href="/terms" className="font-medium text-slate-100 hover:underline">
             Terms of Service
           </Link>{" "}
           and{" "}
-          <Link href="/privacy" className="hover:underline">
+          <Link href="/privacy" className="font-medium text-slate-100 hover:underline">
             Privacy Policy
           </Link>
-        </p>
-      </div>
-    </div>
+        </>
+      }
+    >
+      <LoginCard />
+    </AuthPageLayout>
   );
 }

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,17 @@
+import type React from "react";
+
+import { AuthPageLayout } from "@/components/auth-page-layout";
+
+import { ResetPasswordCard } from "./reset-password-card";
+
+export default function ResetPasswordPage(): React.ReactElement {
+  return (
+    <AuthPageLayout
+      eyebrow="Secure your account"
+      title="Set a new password"
+      description="Choose a strong password to finish the reset."
+    >
+      <ResetPasswordCard />
+    </AuthPageLayout>
+  );
+}

--- a/app/reset-password/reset-password-card.tsx
+++ b/app/reset-password/reset-password-card.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, Eye, EyeOff, Loader2, ShieldCheck } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { supabase } from "@/lib/supabaseClient";
+
+export function ResetPasswordCard() {
+  const router = useRouter();
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [formData, setFormData] = useState({
+    password: "",
+    confirmPassword: "",
+  });
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    if (!formData.password || !formData.confirmPassword) {
+      setError("Please complete both password fields.");
+      return;
+    }
+
+    if (formData.password !== formData.confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const { error: updateError } = await supabase.auth.updateUser({
+        password: formData.password,
+      });
+
+      if (updateError) {
+        setError(updateError.message);
+        setIsLoading(false);
+        return;
+      }
+
+      setSuccess(true);
+      setIsLoading(false);
+
+      setTimeout(() => {
+        router.push("/login");
+      }, 1500);
+    } catch (updateException) {
+      console.error(updateException);
+      setError("We couldn't update your password. Please try again.");
+      setIsLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <Card className="border border-white/10 bg-background/95 shadow-lg">
+        <CardHeader className="space-y-2 text-center">
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-emerald-500/15">
+            <ShieldCheck className="h-7 w-7 text-emerald-400" />
+          </div>
+          <CardTitle className="text-2xl font-semibold">Password updated</CardTitle>
+          <CardDescription>You're all set. We'll take you back to sign in.</CardDescription>
+        </CardHeader>
+        <CardFooter className="justify-center">
+          <Button asChild variant="outline" className="gap-2">
+            <Link href="/login">
+              <ArrowLeft className="h-4 w-4" />
+              Return to login now
+            </Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="border border-white/10 bg-background/95 shadow-lg">
+      <CardHeader className="space-y-2 text-center">
+        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+          <ShieldCheck className="h-6 w-6 text-primary" />
+        </div>
+        <CardTitle className="text-2xl font-semibold">Create a new password</CardTitle>
+        <CardDescription>Enter and confirm your new password to finish.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error && (
+          <div className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+            {error}
+          </div>
+        )}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="password">New password</Label>
+            <div className="relative">
+              <Input
+                id="password"
+                name="password"
+                type={showPassword ? "text" : "password"}
+                placeholder="Create a strong password"
+                value={formData.password}
+                onChange={handleChange}
+                required
+                autoComplete="new-password"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="absolute right-0 top-0 h-full px-3 py-2 text-muted-foreground hover:bg-transparent"
+                onClick={() => setShowPassword((prev) => !prev)}
+              >
+                {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="confirmPassword">Confirm password</Label>
+            <div className="relative">
+              <Input
+                id="confirmPassword"
+                name="confirmPassword"
+                type={showConfirmPassword ? "text" : "password"}
+                placeholder="Repeat your new password"
+                value={formData.confirmPassword}
+                onChange={handleChange}
+                required
+                autoComplete="new-password"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="absolute right-0 top-0 h-full px-3 py-2 text-muted-foreground hover:bg-transparent"
+                onClick={() => setShowConfirmPassword((prev) => !prev)}
+              >
+                {showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </Button>
+            </div>
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full bg-gradient-to-r from-primary to-primary/80 text-white shadow-md transition hover:from-primary/90 hover:to-primary"
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Updating password
+              </span>
+            ) : (
+              "Save new password"
+            )}
+          </Button>
+        </form>
+      </CardContent>
+      <CardFooter>
+        <p className="w-full text-center text-sm text-muted-foreground">
+          Changed your mind?{" "}
+          <Link href="/login" className="font-medium text-primary hover:text-primary/80">
+            Return to sign in
+          </Link>
+        </p>
+      </CardFooter>
+    </Card>
+  );
+}
+
+export default ResetPasswordCard;

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,60 +1,31 @@
 import type React from "react";
+
 import Link from "next/link";
+
+import { AuthPageLayout } from "@/components/auth-page-layout";
+
 import SignupCard from "./signup-card";
 
 export default function RegisterPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background to-muted/50 p-4">
-      <div className="w-full max-w-md">
-        {/* Logo and Header */}
-        <div className="text-center mb-8">
-          <Link href="/" className="inline-flex items-center gap-2 mb-4">
-            <svg
-              width="32"
-              height="32"
-              viewBox="0 0 32 32"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8 6C8 4.89543 8.89543 4 10 4H22C23.1046 4 24 4.89543 24 6V26C24 27.1046 23.1046 28 22 28H10C8.89543 28 8 27.1046 8 26V6Z"
-                fill="#FF5722"
-              />
-              <path
-                d="M14 10L18 14M18 10L14 14"
-                stroke="#0D47A1"
-                strokeWidth="2"
-                strokeLinecap="round"
-              />
-              <path
-                d="M14 18L18 22M18 18L14 22"
-                stroke="#0D47A1"
-                strokeWidth="2"
-                strokeLinecap="round"
-              />
-            </svg>
-            <span className="text-2xl font-bold text-primary">CodeJoin</span>
-          </Link>
-          <h1 className="text-2xl font-bold">Create your account</h1>
-          <p className="text-muted-foreground">
-            Join thousands of developers coding together
-          </p>
-        </div>
-
-        <SignupCard />
-
-        {/* Footer */}
-        <p className="text-center text-xs text-muted-foreground mt-8">
+    <AuthPageLayout
+      eyebrow="Create your account"
+      title="Join CodeJoin"
+      description="Set up your workspace credentials to get started."
+      footer={
+        <>
           By creating an account, you agree to our{" "}
-          <Link href="/terms" className="hover:underline">
+          <Link href="/terms" className="font-medium text-slate-100 hover:underline">
             Terms of Service
           </Link>{" "}
           and{" "}
-          <Link href="/privacy" className="hover:underline">
+          <Link href="/privacy" className="font-medium text-slate-100 hover:underline">
             Privacy Policy
           </Link>
-        </p>
-      </div>
-    </div>
+        </>
+      }
+    >
+      <SignupCard />
+    </AuthPageLayout>
   );
 }

--- a/app/signup/signup-card.tsx
+++ b/app/signup/signup-card.tsx
@@ -13,7 +13,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-import { Eye, EyeOff, Github, Mail, Check, X } from "lucide-react";
+import { Eye, EyeOff, Check, X, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { LoginGithub } from "@/components/login-github";
 import { LoginGoogle } from "@/components/login-google";
@@ -152,33 +152,35 @@ export default function SignupCard() {
   );
 
   return (
-    <Card>
-      <CardHeader className="space-y-1">
-        <CardTitle className="text-2xl text-center">Sign up</CardTitle>
-        <CardDescription className="text-center">
-          Create your account to start collaborating
-        </CardDescription>
+    <Card className="border border-white/10 bg-background/95 shadow-lg">
+      <CardHeader className="space-y-2 text-center">
+        <CardTitle className="text-2xl font-semibold">Create account</CardTitle>
+        <CardDescription>Sign up with email or your preferred provider.</CardDescription>
       </CardHeader>
-      <CardContent className="space-y-4">
+      <CardContent className="space-y-6">
         {/* Social Login Buttons */}
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-3">
           <LoginGithub />
           <LoginGoogle />
         </div>
 
         <div className="relative">
           <div className="absolute inset-0 flex items-center">
-            <Separator className="w-full" />
+            <Separator className="w-full bg-white/10" />
           </div>
           <div className="relative flex justify-center text-xs uppercase">
-            <span className="bg-background px-2 text-muted-foreground">
-              Or continue with
+            <span className="rounded-full bg-background px-3 py-1 text-muted-foreground">
+              Or sign up with email
             </span>
           </div>
         </div>
 
         {/* Show error if any */}
-        {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+        {error && (
+          <div className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+            {error}
+          </div>
+        )}
 
         {/* Registration Form */}
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -188,7 +190,7 @@ export default function SignupCard() {
               id="name"
               name="name"
               type="text"
-              placeholder="Enter your full name"
+              placeholder="Alex Johnson"
               value={formData.name}
               onChange={handleInputChange}
               required
@@ -202,14 +204,14 @@ export default function SignupCard() {
               name="email"
               type="email"
               autoComplete="username"
-              placeholder="Enter your email"
+              placeholder="name@company.com"
               value={formData.email}
               onChange={handleInputChange}
               required
             />
           </div>
 
-          <div className="space-y-2">
+          <div className="space-y-3">
             <Label htmlFor="password">Password</Label>
             <div className="relative">
               <Input
@@ -217,7 +219,7 @@ export default function SignupCard() {
                 name="password"
                 autoComplete="new-password"
                 type={showPassword ? "text" : "password"}
-                placeholder="Create a password"
+                placeholder="Create a secure password"
                 value={formData.password}
                 onChange={handleInputChange}
                 required
@@ -226,7 +228,7 @@ export default function SignupCard() {
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                className="absolute right-0 top-0 h-full px-3 py-2 text-muted-foreground hover:bg-transparent"
                 onClick={() => setShowPassword(!showPassword)}
               >
                 {showPassword ? (
@@ -239,8 +241,8 @@ export default function SignupCard() {
 
             {/* Password Requirements */}
             {formData.password && (
-              <div className="space-y-1 p-3 bg-muted/50 rounded-md">
-                <p className="text-sm font-medium">Password requirements:</p>
+              <div className="space-y-2 rounded-lg border border-white/10 bg-muted/30 p-4 text-sm">
+                <p className="font-medium text-slate-200">Password requirements</p>
                 <ValidationItem
                   isValid={passwordValidation.minLength}
                   text="At least 8 characters"
@@ -273,7 +275,7 @@ export default function SignupCard() {
                 name="confirmPassword"
                 type={showConfirmPassword ? "text" : "password"}
                 autoComplete="new-password"
-                placeholder="Confirm your password"
+                placeholder="Repeat your password"
                 value={formData.confirmPassword}
                 onChange={handleInputChange}
                 required
@@ -282,7 +284,7 @@ export default function SignupCard() {
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                className="absolute right-0 top-0 h-full px-3 py-2 text-muted-foreground hover:bg-transparent"
                 onClick={() => setShowConfirmPassword(!showConfirmPassword)}
               >
                 {showConfirmPassword ? (
@@ -294,29 +296,36 @@ export default function SignupCard() {
             </div>
             {formData.confirmPassword &&
               formData.password !== formData.confirmPassword && (
-                <p className="text-sm text-red-600">Passwords don't match</p>
+                <p className="text-sm text-red-500">Passwords don't match</p>
               )}
           </div>
 
           <Button
             type="submit"
-            className="w-full"
+            className="w-full bg-gradient-to-r from-primary to-primary/80 text-white shadow-md transition hover:from-primary/90 hover:to-primary"
             disabled={
               isLoading ||
               !isPasswordValid() ||
               formData.password !== formData.confirmPassword
             }
           >
-            {isLoading ? "Creating account..." : "Create account"}
+            {isLoading ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Creating account
+              </span>
+            ) : (
+              "Create account"
+            )}
           </Button>
         </form>
       </CardContent>
       <CardFooter>
-        <p className="text-center text-sm text-muted-foreground w-full">
+        <p className="w-full text-center text-sm text-muted-foreground">
           Already have an account?{" "}
           <Link
             href="/login"
-            className="text-primary hover:underline font-medium"
+            className="font-medium text-primary transition hover:text-primary/80"
           >
             Sign in
           </Link>

--- a/components/auth-page-layout.tsx
+++ b/components/auth-page-layout.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import Link from "next/link";
+import { type ReactNode } from "react";
+import { ArrowLeft } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface AuthPageLayoutProps {
+  children: ReactNode;
+  title: string;
+  description?: string;
+  eyebrow?: string;
+  footer?: ReactNode;
+  backHref?: string;
+  backLabel?: string;
+}
+
+export function AuthPageLayout({
+  children,
+  eyebrow,
+  title,
+  description,
+  footer,
+  backHref = "/",
+  backLabel = "Back to landing",
+}: AuthPageLayoutProps) {
+  return (
+    <div className="relative flex min-h-screen flex-col overflow-hidden bg-slate-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-32 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-primary/25 blur-3xl" />
+        <div className="absolute -bottom-36 right-1/2 h-72 w-72 translate-x-1/2 rounded-full bg-indigo-500/20 blur-3xl" />
+      </div>
+
+      <header className="relative z-10 flex items-center justify-between px-6 py-6">
+        <Link href="/" className="inline-flex items-center gap-2 text-sm font-medium text-slate-100 transition hover:text-white">
+          <svg
+            width="22"
+            height="22"
+            viewBox="0 0 32 32"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className="drop-shadow"
+          >
+            <path
+              d="M8 6C8 4.89543 8.89543 4 10 4H22C23.1046 4 24 4.89543 24 6V26C24 27.1046 23.1046 28 22 28H10C8.89543 28 8 27.1046 8 26V6Z"
+              fill="#f97316"
+            />
+            <path
+              d="M14 10L18 14M18 10L14 14"
+              stroke="#0f172a"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+            <path
+              d="M14 18L18 22M18 18L14 22"
+              stroke="#0f172a"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+          <span className="text-base font-semibold">CodeJoin</span>
+        </Link>
+        <Button asChild variant="ghost" className="text-slate-100 hover:bg-white/10 hover:text-white">
+          <Link href={backHref} className="inline-flex items-center gap-2">
+            <ArrowLeft className="h-4 w-4" />
+            {backLabel}
+          </Link>
+        </Button>
+      </header>
+
+      <main className="relative z-10 flex flex-1 items-center justify-center px-4 pb-16 pt-4">
+        <div className="w-full max-w-md space-y-6">
+          <div className="space-y-2 text-center">
+            {eyebrow && (
+              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-300/80">{eyebrow}</p>
+            )}
+            <h1 className="text-3xl font-semibold text-white sm:text-4xl">{title}</h1>
+            {description && <p className="text-sm text-slate-300">{description}</p>}
+          </div>
+
+          <div className="rounded-3xl border border-white/10 bg-background/90 p-6 shadow-2xl backdrop-blur">
+            {children}
+          </div>
+
+          {footer && <div className="text-center text-xs text-slate-400">{footer}</div>}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default AuthPageLayout;


### PR DESCRIPTION
## Summary
- replace the shared auth page layout with a single-column, low-copy frame that centers each form and keeps the back-to-landing control
- shorten the login, signup, forgot-password, and reset-password page headers so the forms are the primary focus
- streamline each auth card's copy and success states to keep instructions brief and easy to scan

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d8910ab883328544977392341a3d