### PR TITLE
feat: enrich dashboard project controls

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,6 +7,13 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -28,16 +35,21 @@ import {
   Calendar,
   Activity as ActivityIcon,
   AlertTriangle,
+  LayoutGrid,
+  List,
+  Star as StarIcon,
 } from "lucide-react";
 import Link from "next/link";
 import ProjectCard from "@/components/project-card";
 import RecentActivity from "@/components/recent-activity";
 import QuickStats from "@/components/quick-stats";
-import Image from "next/image";
 import dynamic from "next/dynamic";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { supabase } from "@/lib/supabaseClient";
 import { Project, Activity, RawActivity } from "@/lib/types";
+import { toast } from "@/hooks/use-toast";
+
+const STATUS_OPTIONS = ["active", "planning", "completed", "archived"] as const;
 
 const UserDropdown = dynamic(() => import("@/components/user-dropdown"), {
   ssr: false,
@@ -140,7 +152,10 @@ function DeleteConfirmation({
 
 export default function DashboardPage() {
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedFilter, setSelectedFilter] = useState("all");
+  const [selectedFilter, setSelectedFilter] = useState<
+    "all" | "active" | "planning" | "completed" | "archived" | "starred"
+  >("all");
+  const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
 
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
@@ -150,6 +165,7 @@ export default function DashboardPage() {
   const [projectToDelete, setProjectToDelete] = useState<Project | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [openDropdowns, setOpenDropdowns] = useState<Set<string>>(new Set());
+  const [pendingProjects, setPendingProjects] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     async function getDashboardData() {
@@ -201,7 +217,12 @@ export default function DashboardPage() {
           // Handle projects data
           if (projectsResponse.error) throw projectsResponse.error;
           if (projectsResponse.data) {
-            setProjects(projectsResponse.data);
+            setProjects(
+              projectsResponse.data.map((project: Project) => ({
+                ...project,
+                status: project.status?.toLowerCase() ?? project.status,
+              }))
+            );
           }
 
           // Handle and format activities data
@@ -345,6 +366,106 @@ export default function DashboardPage() {
     });
   };
 
+  const updatePendingState = (projectId: string, isPending: boolean) => {
+    setPendingProjects((prev) => {
+      const next = new Set(prev);
+      if (isPending) {
+        next.add(projectId);
+      } else {
+        next.delete(projectId);
+      }
+      return next;
+    });
+  };
+
+  const handleToggleStar = async (project: Project, nextValue: boolean) => {
+    updatePendingState(project.id, true);
+    const previousValue = Boolean(project.isStarred);
+
+    setProjects((prev) =>
+      prev.map((item) =>
+        item.id === project.id ? { ...item, isStarred: nextValue } : item
+      )
+    );
+
+    try {
+      const { error } = await supabase
+        .from("projects")
+        .update({ isStarred: nextValue })
+        .eq("id", project.id);
+
+      if (error) {
+        throw error;
+      }
+
+      toast({
+        title: nextValue ? "Project starred" : "Project unstarred",
+        description: nextValue
+          ? `${project.name} is now pinned to the top of your workspace.`
+          : `${project.name} has been removed from your starred projects.`,
+      });
+    } catch (error) {
+      console.error("Failed to toggle star state", error);
+      setProjects((prev) =>
+        prev.map((item) =>
+          item.id === project.id ? { ...item, isStarred: previousValue } : item
+        )
+      );
+      toast({
+        variant: "destructive",
+        title: "Unable to update project",
+        description: "Please try starring the project again.",
+      });
+    } finally {
+      updatePendingState(project.id, false);
+    }
+  };
+
+  const handleStatusChange = async (project: Project, nextStatus: string) => {
+    if (project.status === nextStatus) return;
+
+    updatePendingState(project.id, true);
+    const previousStatus = project.status;
+
+    setProjects((prev) =>
+      prev.map((item) =>
+        item.id === project.id ? { ...item, status: nextStatus } : item
+      )
+    );
+
+    try {
+      const { error } = await supabase
+        .from("projects")
+        .update({ status: nextStatus })
+        .eq("id", project.id);
+
+      if (error) {
+        throw error;
+      }
+
+      const formattedStatus =
+        nextStatus.charAt(0).toUpperCase() + nextStatus.slice(1);
+      toast({
+        title: "Project status updated",
+        description: `${project.name} is now marked as ${formattedStatus}.`,
+      });
+    } catch (error) {
+      console.error("Failed to update project status", error);
+      setProjects((prev) =>
+        prev.map((item) =>
+          item.id === project.id ? { ...item, status: previousStatus } : item
+        )
+      );
+      toast({
+        variant: "destructive",
+        title: "Unable to update status",
+        description: "Something went wrong while saving the new status.",
+      });
+    } finally {
+      updatePendingState(project.id, false);
+    }
+  };
+
   if (loading) {
     return <div>Loading your dashboard...</div>;
   }
@@ -356,7 +477,10 @@ export default function DashboardPage() {
         searchQuery.toLowerCase()
       );
     const matchesFilter =
-      selectedFilter === "all" || project.status === selectedFilter;
+      selectedFilter === "all" ||
+      (selectedFilter === "starred"
+        ? Boolean(project.isStarred)
+        : project.status === selectedFilter);
     return matchesSearch && matchesFilter;
   });
 
@@ -427,53 +551,92 @@ export default function DashboardPage() {
         <div className="grid gap-6 lg:grid-cols-4">
           {/* Projects Section */}
           <div className="lg:col-span-3">
-            <div className="flex items-center justify-between mb-6">
-              <h2 className="text-2xl font-bold">My Projects</h2>
-              <div className="flex items-center gap-2">
-                <div className="relative">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                  <Input
-                    placeholder="Search projects..."
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    className="pl-10 w-64"
-                  />
+            <div className="mb-6 space-y-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <h2 className="text-2xl font-bold">My Projects</h2>
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className="relative">
+                    <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                    <Input
+                      placeholder="Search projects..."
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      className="pl-10 w-64"
+                    />
+                  </div>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="outline" size="sm">
+                        <Filter className="h-4 w-4 mr-2" />
+                        Filter
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent>
+                      <DropdownMenuItem onClick={() => setSelectedFilter("all")}>
+                        All Projects
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => setSelectedFilter("active")}
+                      >
+                        Active
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => setSelectedFilter("planning")}
+                      >
+                        Planning
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => setSelectedFilter("completed")}
+                      >
+                        Completed
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => setSelectedFilter("archived")}
+                      >
+                        Archived
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                  <Button
+                    variant={selectedFilter === "starred" ? "default" : "outline"}
+                    size="sm"
+                    onClick={() =>
+                      setSelectedFilter((current) =>
+                        current === "starred" ? "all" : "starred"
+                      )
+                    }
+                    className="flex items-center gap-2"
+                  >
+                    <StarIcon
+                      className={`h-4 w-4 ${
+                        selectedFilter === "starred"
+                          ? "fill-yellow-400 text-yellow-500"
+                          : ""
+                      }`}
+                    />
+                    Starred
+                  </Button>
                 </div>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="outline" size="sm">
-                      <Filter className="h-4 w-4 mr-2" />
-                      Filter
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent>
-                    <DropdownMenuItem onClick={() => setSelectedFilter("all")}>
-                      All Projects
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setSelectedFilter("active")}
-                    >
-                      Active
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setSelectedFilter("completed")}
-                    >
-                      Completed
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setSelectedFilter("archived")}
-                    >
-                      Archived
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
               </div>
+              <p className="text-sm text-muted-foreground">
+                Showing {filteredProjects.length} of {projects.length} projects
+              </p>
             </div>
 
-            <Tabs defaultValue="grid" className="w-full">
-              <TabsList className="grid w-full grid-cols-2 max-w-[200px] mb-4">
-                <TabsTrigger value="grid">Grid</TabsTrigger>
-                <TabsTrigger value="list">List</TabsTrigger>
+            <Tabs
+              value={viewMode}
+              onValueChange={(value) => setViewMode(value as "grid" | "list")}
+              className="w-full"
+            >
+              <TabsList className="grid w-full grid-cols-2 max-w-[220px] mb-4">
+                <TabsTrigger value="grid" className="flex items-center gap-2">
+                  <LayoutGrid className="h-4 w-4" />
+                  Grid
+                </TabsTrigger>
+                <TabsTrigger value="list" className="flex items-center gap-2">
+                  <List className="h-4 w-4" />
+                  List
+                </TabsTrigger>
               </TabsList>
 
               <TabsContent value="grid">
@@ -483,6 +646,14 @@ export default function DashboardPage() {
                       key={project.id}
                       project={project}
                       onDelete={openDeleteDialog}
+                      onToggleStar={(nextValue) =>
+                        handleToggleStar(project, nextValue)
+                      }
+                      onStatusChange={(nextStatus) =>
+                        handleStatusChange(project, nextStatus)
+                      }
+                      isUpdating={pendingProjects.has(project.id)}
+                      statusOptions={STATUS_OPTIONS}
                     />
                   ))}
                 </div>
@@ -492,7 +663,7 @@ export default function DashboardPage() {
                 <div className="space-y-2">
                   {filteredProjects.map((project) => (
                     <Card key={project.id} className="p-4">
-                      <div className="flex items-center justify-between">
+                      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                         <div className="flex items-center gap-4">
                           <img
                             src={project.thumbnail || "/placeholder.svg"}
@@ -506,7 +677,54 @@ export default function DashboardPage() {
                             </p>
                           </div>
                         </div>
-                        <div className="flex items-center gap-4">
+                        <div className="flex flex-wrap items-center gap-3">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className={`h-8 w-8 ${
+                              project.isStarred
+                                ? "text-yellow-500 hover:text-yellow-400"
+                                : "text-muted-foreground"
+                            }`}
+                            onClick={() =>
+                              handleToggleStar(
+                                project,
+                                !(project.isStarred ?? false)
+                              )
+                            }
+                            disabled={pendingProjects.has(project.id)}
+                            aria-pressed={Boolean(project.isStarred)}
+                          >
+                            <StarIcon
+                              className={`h-4 w-4 ${
+                                project.isStarred
+                                  ? "fill-yellow-400 text-yellow-400"
+                                  : ""
+                              }`}
+                            />
+                            <span className="sr-only">
+                              {project.isStarred ? "Unstar" : "Star"} project
+                            </span>
+                          </Button>
+                          <Select
+                            value={(project.status as string | undefined) ?? "active"}
+                            onValueChange={(value) =>
+                              handleStatusChange(project, value)
+                            }
+                            disabled={pendingProjects.has(project.id)}
+                          >
+                            <SelectTrigger size="sm" className="min-w-[140px]">
+                              <SelectValue placeholder="Set status" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {STATUS_OPTIONS.map((status) => (
+                                <SelectItem key={status} value={status}>
+                                  {status.charAt(0).toUpperCase() +
+                                    status.slice(1)}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
                           <Badge
                             variant={
                               project.status === "active"
@@ -514,7 +732,7 @@ export default function DashboardPage() {
                                 : "secondary"
                             }
                           >
-                            {project.status}
+                            {project.status ?? "active"}
                           </Badge>
                           <div className="flex items-center gap-1 text-sm text-muted-foreground">
                             <Users className="h-4 w-4" />
@@ -526,10 +744,12 @@ export default function DashboardPage() {
                           </div>
                           <DropdownMenu
                             open={openDropdowns.has(project.id)}
-                            onOpenChange={(open) => handleDropdownOpenChange(project.id, open)}
+                            onOpenChange={(open) =>
+                              handleDropdownOpenChange(project.id, open)
+                            }
                           >
                             <DropdownMenuTrigger asChild>
-                              <Button variant="ghost" size="sm">
+                              <Button variant="ghost" size="icon">
                                 <MoreHorizontal className="h-4 w-4" />
                               </Button>
                             </DropdownMenuTrigger>
@@ -540,18 +760,27 @@ export default function DashboardPage() {
                                   Open
                                 </Link>
                               </DropdownMenuItem>
-                              <DropdownMenuItem onClick={() => {
-                                if (navigator.share) {
-                                  navigator.share({
-                                    title: project.name,
-                                    text: project.description || 'Check out this project',
-                                    url: `${window.location.origin}/project/${project.id}`
-                                  });
-                                } else {
-                                  navigator.clipboard.writeText(`${window.location.origin}/project/${project.id}`);
-                                  alert('Project link copied to clipboard!');
-                                }
-                              }}>
+                          <DropdownMenuItem
+                            onClick={() => {
+                              if (typeof navigator !== "undefined" && navigator.share) {
+                                navigator.share({
+                                  title: project.name,
+                                  text:
+                                    project.description ||
+                                    "Check out this project",
+                                  url: `${window.location.origin}/project/${project.id}`,
+                                });
+                              } else if (
+                                typeof navigator !== "undefined" &&
+                                navigator.clipboard
+                              ) {
+                                navigator.clipboard.writeText(
+                                  `${window.location.origin}/project/${project.id}`
+                                );
+                                alert("Project link copied to clipboard!");
+                              }
+                            }}
+                          >
                                 <Share2 className="h-4 w-4 mr-2" />
                                 Share
                               </DropdownMenuItem>

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -11,6 +11,13 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -32,10 +39,27 @@ import { Project } from "@/lib/types";
 interface ProjectCardProps {
   project: Project;
   onDelete?: (project: Project) => void;
+  onToggleStar?: (nextValue: boolean) => void;
+  onStatusChange?: (nextStatus: string) => void;
+  isUpdating?: boolean;
+  statusOptions?: readonly string[];
 }
 
-export default function ProjectCard({ project, onDelete }: ProjectCardProps) {
+export default function ProjectCard({
+  project,
+  onDelete,
+  onToggleStar,
+  onStatusChange,
+  isUpdating = false,
+  statusOptions,
+}: ProjectCardProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const availableStatuses = statusOptions ?? [
+    "active",
+    "planning",
+    "completed",
+    "archived",
+  ];
 
   const handleDelete = () => {
     setDropdownOpen(false); // Close dropdown immediately
@@ -44,61 +68,116 @@ export default function ProjectCard({ project, onDelete }: ProjectCardProps) {
     }, 100);
   };
 
+  const isStarred = Boolean(project.isStarred);
+  const currentStatus =
+    (project.status as string | undefined)?.toLowerCase() ?? "active";
+  const canToggleStar = typeof onToggleStar === "function";
+  const canChangeStatus = typeof onStatusChange === "function";
+
   return (
     <Card className="group hover:shadow-md transition-shadow">
       <CardHeader className="pb-2">
-        <div className="flex items-start justify-between">
-          <div className="flex items-center gap-2">
-            <CardTitle className="text-lg">{project.name}</CardTitle>
-            {project.isStarred && (
-              <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
-            )}
+        <div className="flex items-start justify-between gap-2">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <CardTitle className="text-lg">{project.name}</CardTitle>
+              {!canToggleStar && isStarred && (
+                <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+              )}
+            </div>
+            <CardDescription className="line-clamp-2">
+              {project.description}
+            </CardDescription>
           </div>
-          <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="opacity-0 group-hover:opacity-100"
-              >
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuItem asChild>
-                <Link href={`/project/${project.id}`}>
-                  <Eye className="h-4 w-4 mr-2" />
-                  Open
-                </Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem>
-                <Share2 className="h-4 w-4 mr-2" />
-                Share
-              </DropdownMenuItem>
-              <DropdownMenuItem asChild>
-                <Link href={`/project/${project.id}/settings`}>
-                  <Settings className="h-4 w-4 mr-2" />
-                  <span>Settings</span>
-                </Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="text-destructive"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  console.log('ProjectCard delete clicked!', project);
-                  handleDelete();
-                }}
-              >
-                <Trash2 className="h-4 w-4 mr-2" />
-                Delete
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className={`h-8 w-8 ${
+                isStarred
+                  ? "text-yellow-500 hover:text-yellow-400"
+                  : "text-muted-foreground"
+              }`}
+              onClick={() => {
+                if (canToggleStar) {
+                  onToggleStar?.(!isStarred);
+                }
+              }}
+              disabled={!canToggleStar || isUpdating}
+              aria-pressed={isStarred}
+            >
+              <Star
+                className={`h-4 w-4 ${
+                  isStarred ? "fill-yellow-400 text-yellow-400" : ""
+                }`}
+              />
+              <span className="sr-only">
+                {isStarred ? "Unstar" : "Star"} project
+              </span>
+            </Button>
+            <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="opacity-0 group-hover:opacity-100"
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem asChild>
+                  <Link href={`/project/${project.id}`}>
+                    <Eye className="h-4 w-4 mr-2" />
+                    Open
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => {
+                    if (typeof navigator !== "undefined" && navigator.share) {
+                      navigator.share({
+                        title: project.name,
+                        text:
+                          project.description || "Check out this project",
+                        url: `${window.location.origin}/project/${project.id}`,
+                      });
+                    } else if (
+                      typeof navigator !== "undefined" &&
+                      navigator.clipboard
+                    ) {
+                      navigator.clipboard.writeText(
+                        `${window.location.origin}/project/${project.id}`
+                      );
+                      alert("Project link copied to clipboard!");
+                    }
+                    setDropdownOpen(false);
+                  }}
+                >
+                  <Share2 className="h-4 w-4 mr-2" />
+                  Share
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link href={`/project/${project.id}/settings`}>
+                    <Settings className="h-4 w-4 mr-2" />
+                    <span>Settings</span>
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="text-destructive"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    console.log('ProjectCard delete clicked!', project);
+                    handleDelete();
+                  }}
+                >
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
-        <CardDescription className="line-clamp-2">
-          {project.description}
-        </CardDescription>
       </CardHeader>
       <CardContent>
         <div className="aspect-video bg-muted rounded-lg mb-4 overflow-hidden">
@@ -117,7 +196,7 @@ export default function ProjectCard({ project, onDelete }: ProjectCardProps) {
           ))}
         </div>
 
-        <div className="flex items-center justify-between text-sm text-muted-foreground mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground mb-4">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-1">
               <Users className="h-4 w-4" />
@@ -128,11 +207,33 @@ export default function ProjectCard({ project, onDelete }: ProjectCardProps) {
               {new Date(project.updated_at).toLocaleDateString()}
             </div>
           </div>
-          <Badge
-            variant={project.status === "active" ? "default" : "secondary"}
-          >
-            {project.status}
-          </Badge>
+          <div className="flex items-center gap-2">
+            <Select
+              value={currentStatus}
+              onValueChange={(value) => {
+                if (canChangeStatus) {
+                  onStatusChange?.(value);
+                }
+              }}
+              disabled={!canChangeStatus || isUpdating}
+            >
+              <SelectTrigger size="sm" className="min-w-[140px]">
+                <SelectValue placeholder="Set status" />
+              </SelectTrigger>
+              <SelectContent>
+                {availableStatuses.map((status) => (
+                  <SelectItem key={status} value={status}>
+                    {status.charAt(0).toUpperCase() + status.slice(1)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Badge
+              variant={currentStatus === "active" ? "default" : "secondary"}
+            >
+              {currentStatus.charAt(0).toUpperCase() + currentStatus.slice(1)}
+            </Badge>
+          </div>
         </div>
 
         <Link href={`/project/${project.id}`}>


### PR DESCRIPTION
## Summary
- add interactive filters, starred toggles, and view controls to the dashboard projects section
- persist project starring and status changes via Supabase with optimistic UI feedback
- refresh project cards with inline star actions, status selectors, and share fallbacks

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ef6103648332b53c6f25467073fe