### PR TITLE
feat: refresh app sidebar navigation

### DIFF
--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,46 +1,139 @@
 "use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
+  SidebarMenu,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import { LayoutDashboard, Layers, Users, Settings } from "lucide-react";
-import { sidebarNavItems } from "./sidebar-nav-items"; // Optional: put nav items in separate file
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { cn } from "@/lib/utils"; // If using ShadCN's `cn` utility
+import { CheckCircle2, Sparkles, Bot } from "lucide-react";
+
+import { sidebarNavSections } from "./sidebar-nav-items";
 
 export function AppSidebar() {
   const pathname = usePathname();
 
   return (
-    <Sidebar>
-      <SidebarHeader />
-      <SidebarContent>
-        <SidebarGroup title="Navigation">
-          {sidebarNavItems.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={cn(
-                "flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-md transition-colors hover:bg-muted",
-                pathname === item.href
-                  ? "bg-muted text-primary"
-                  : "text-muted-foreground"
-              )}
-            >
-              <item.icon className="w-4 h-4" />
-              {item.title}
+    <Sidebar className="border-r border-sidebar-border/60 bg-sidebar/95">
+      <SidebarHeader className="border-b border-sidebar-border/60">
+        <Link
+          href="/dashboard"
+          className="flex items-center gap-3 rounded-md px-3 py-2 transition-colors hover:bg-sidebar-accent"
+        >
+          <span className="grid size-9 place-items-center rounded-lg bg-primary/10 text-primary">
+            <Sparkles className="h-5 w-5" />
+          </span>
+          <div className="flex flex-col">
+            <span className="text-sm font-semibold leading-tight">CodeJoin</span>
+            <span className="text-xs text-muted-foreground">
+              Collaborative AI workspace
+            </span>
+          </div>
+        </Link>
+        <div className="flex items-center justify-between px-3">
+          <Badge className="rounded-full border-primary/30 bg-primary/10 text-[0.65rem] font-medium uppercase tracking-wide text-primary">
+            Pro plan
+          </Badge>
+          <Button asChild size="sm" variant="outline" className="h-8 gap-2 text-xs">
+            <Link href="/ai-assistant">
+              <Bot className="h-4 w-4" />
+              Launch AI
             </Link>
-          ))}
-        </SidebarGroup>
+          </Button>
+        </div>
+      </SidebarHeader>
+      <SidebarContent className="px-1 py-4">
+        {sidebarNavSections.map((section) => (
+          <SidebarGroup key={section.title} className="gap-1">
+            <SidebarGroupLabel className="px-2 text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground/80">
+              {section.title}
+            </SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {section.items.map((item) => {
+                  const isActive =
+                    pathname === item.href || pathname.startsWith(`${item.href}/`);
+
+                  return (
+                    <SidebarMenuItem key={item.href}>
+                      <SidebarMenuButton
+                        asChild
+                        tooltip={item.title}
+                        isActive={isActive}
+                        className="group items-start gap-3 py-2"
+                      >
+                        <Link href={item.href}>
+                          <item.icon
+                            className={cn(
+                              "h-4 w-4 text-muted-foreground transition-colors",
+                              isActive && "text-primary"
+                            )}
+                          />
+                          <span className="flex flex-1 flex-col text-left">
+                            <span className="text-sm font-medium leading-tight">
+                              {item.title}
+                            </span>
+                            {item.description ? (
+                              <span
+                                className={cn(
+                                  "text-xs text-muted-foreground transition-colors group-data-[collapsible=icon]:hidden",
+                                  isActive && "text-sidebar-accent-foreground/80"
+                                )}
+                              >
+                                {item.description}
+                              </span>
+                            ) : null}
+                          </span>
+                        </Link>
+                      </SidebarMenuButton>
+                      {item.badge ? (
+                        <SidebarMenuBadge className="border border-primary/30 bg-primary/10 text-[0.65rem] font-semibold uppercase tracking-wide text-primary">
+                          {item.badge}
+                        </SidebarMenuBadge>
+                      ) : null}
+                    </SidebarMenuItem>
+                  );
+                })}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ))}
       </SidebarContent>
-      <SidebarFooter>
-        {/* Optional: User info, logout button, etc */}
-        <div className="text-xs text-muted-foreground px-3 py-1">
-          Logged in as shadcn
+      <SidebarFooter className="border-t border-sidebar-border/60 p-3">
+        <div className="rounded-lg border border-sidebar-border/60 bg-sidebar/70 p-3">
+          <div className="flex items-center gap-3">
+            <span className="grid size-8 place-items-center rounded-full bg-emerald-500/15 text-emerald-400">
+              <CheckCircle2 className="h-4 w-4" />
+            </span>
+            <div className="flex flex-col">
+              <span className="text-xs font-semibold text-sidebar-foreground">
+                Workspace synced
+              </span>
+              <span className="text-[11px] text-muted-foreground">
+                All systems operational
+              </span>
+            </div>
+          </div>
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+            className="mt-3 w-full justify-center gap-2 text-xs"
+          >
+            <Link href="/settings">Manage settings</Link>
+          </Button>
         </div>
       </SidebarFooter>
     </Sidebar>

--- a/components/sidebar-nav-items.ts
+++ b/components/sidebar-nav-items.ts
@@ -1,24 +1,79 @@
-import { LayoutDashboard, Layers, Users, Settings } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import {
+  LayoutDashboard,
+  Bot,
+  FolderPlus,
+  Layers,
+  Users,
+  Settings,
+} from "lucide-react";
 
-export const sidebarNavItems = [
+export type SidebarNavItem = {
+  title: string;
+  href: string;
+  icon: LucideIcon;
+  description?: string;
+  badge?: string;
+};
+
+export type SidebarNavSection = {
+  title: string;
+  items: SidebarNavItem[];
+};
+
+export const sidebarNavSections: SidebarNavSection[] = [
   {
-    title: "Dashboard",
-    href: "/dashboard",
-    icon: LayoutDashboard,
+    title: "Workspace",
+    items: [
+      {
+        title: "Dashboard",
+        description: "Project overview & insights",
+        href: "/dashboard",
+        icon: LayoutDashboard,
+      },
+      {
+        title: "AI Assistant",
+        description: "Chat, voice & code automations",
+        href: "/ai-assistant",
+        icon: Bot,
+        badge: "Beta",
+      },
+    ],
   },
   {
-    title: "Templates",
-    href: "/templates-section",
-    icon: Layers,
+    title: "Creation",
+    items: [
+      {
+        title: "New Project",
+        description: "Spin up a collaborative space",
+        href: "/new-project",
+        icon: FolderPlus,
+      },
+      {
+        title: "Templates",
+        description: "Start from curated blueprints",
+        href: "/templates-section",
+        icon: Layers,
+      },
+    ],
   },
   {
-    title: "Teams",
-    href: "/teams",
-    icon: Users,
-  },
-  {
-    title: "Settings",
-    href: "/settings",
-    icon: Settings,
+    title: "Collaboration",
+    items: [
+      {
+        title: "Teams",
+        description: "Manage invites & permissions",
+        href: "/teams",
+        icon: Users,
+      },
+      {
+        title: "Settings",
+        description: "Workspace preferences",
+        href: "/settings",
+        icon: Settings,
+      },
+    ],
   },
 ];
+
+export const sidebarNavItems = sidebarNavSections.flatMap((section) => section.items);


### PR DESCRIPTION
## Summary
- redesign the application sidebar header, navigation groups, and footer for a richer UI experience
- add structured nav sections that cover dashboard, AI assistant, templates, new project, teams, and settings routes
- surface quick actions and status cues including an AI launch shortcut and workspace health card

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f7fb9c0883328a47d29ed6d1d96b