### PR TITLE
fix: avoid socket disconnect during auth redirects

### DIFF
--- a/components/app-layout.tsx
+++ b/components/app-layout.tsx
@@ -8,6 +8,7 @@ import {
 import { AppSidebar } from "@/components/app-sidebar";
 import { useAuthStatus } from "@/hooks/useAuthStatus";
 import { Button } from "@/components/button";
+import Link from "next/link";
 import { useSelectedLayoutSegment } from "next/navigation";
 import { useState, useEffect } from "react";
 
@@ -70,7 +71,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
             You must be logged in to access dashboard.
           </p>
           <Button asChild>
-            <a href="/login">Log In</a>
+            <Link href="/login">Log In</Link>
           </Button>
         </div>
       </div>

--- a/docs/socket-connection-lifecycle.md
+++ b/docs/socket-connection-lifecycle.md
@@ -1,0 +1,38 @@
+# Socket connection lifecycle during redirects
+
+This note documents why the backend occasionally logs `User disconnected` and
+how to avoid unnecessary disconnects when navigating around the app.
+
+## Where the message comes from
+
+The Socket.IO server logs the message from the `disconnect` listener in
+[`server.js`](../server.js). Whenever a socket closes—for example because the
+browser navigated away—the server prints `User disconnected: <socket id>` to the
+terminal.
+
+## Why redirects triggered the log
+
+The React tree opens the Socket.IO client in the `SocketProvider`. When that
+provider unmounts it calls `socketInstance.close()`, which tells the server that
+the client left. We discovered that some redirects rendered raw `<a>` tags. Raw
+anchors trigger a **full page reload** instead of a client-side transition,
+which unmounts the provider and closes the socket. The server then prints the
+`User disconnected` message.
+
+## Mitigation
+
+Prefer Next.js navigation helpers (`next/link`, `useRouter().push`, etc.) so the
+page transitions happen on the client. The provider remains mounted and the
+socket stays connected.
+
+We fixed the most noticeable occurrence by replacing the login link in the
+protected-route fallback with a `<Link href="/login">`. If new pages introduce a
+hard navigation, look for raw `<a>` tags or `window.location` mutations and
+replace them with Next.js navigation primitives.
+
+## When the log is expected
+
+It is normal to see `User disconnected` when the user intentionally leaves the
+app (closing the tab, refreshing, or losing connectivity). The message is
+informational; if you need to perform cleanup before disconnects, emit a custom
+Socket.IO event such as `leave-project` before navigating away.


### PR DESCRIPTION
## Summary
- document how the Socket.IO connection behaves during redirects and how to avoid unexpected disconnect logs
- replace the raw login anchor in the protected-route fallback with Next.js Link to keep the socket provider mounted during auth redirects

## Testing
- npm run lint *(fails: ESLint must be installed in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d5009393d8833292d5b00eadbbcbf2