### PR TITLE
feat: unify workspace headers

### DIFF
--- a/app/ai-assistant/page.tsx
+++ b/app/ai-assistant/page.tsx
@@ -24,6 +24,8 @@ import AIChat from "@/components/ai-chat"
 import VoiceAssistant from "@/components/voice-assistant"
 import CodeAnalyzer from "@/components/code-analyzer"
 import AITemplates from "@/components/ai-templates"
+import { PageHeader } from "@/components/PageHeader"
+import { SidebarTrigger } from "@/components/ui/sidebar"
 
 export default function AIAssistantPage() {
   const [isVoiceActive, setIsVoiceActive] = useState(false)
@@ -72,19 +74,25 @@ export default function AIAssistantPage() {
 
   return (
     <div className="flex flex-col min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b bg-background/95 backdrop-blur">
-        <div className="container flex h-16 items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="flex items-center gap-2">
-              <Brain className="h-6 w-6 text-primary" />
-              <h1 className="text-xl font-bold">AI Assistant</h1>
-              <Badge variant="outline" className="bg-primary/10 text-primary">
-                Powered by GPT-4 & ElevenLabs
-              </Badge>
-            </div>
+      <PageHeader
+        leading={<SidebarTrigger />}
+        startContent={
+          <div className="hidden items-center gap-2 text-sm font-medium text-muted-foreground sm:flex">
+            <Brain className="h-4 w-4" />
+            Intelligent workspace
           </div>
-          <div className="flex items-center gap-2">
+        }
+        title="AI Assistant"
+        description={
+          <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            <span>Collaborate with real-time AI for planning, coding, and debugging.</span>
+            <Badge variant="outline" className="bg-primary/10 text-primary">
+              Powered by GPT-4 & ElevenLabs
+            </Badge>
+          </div>
+        }
+        actions={
+          <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
             <Button
               variant={isVoiceActive ? "destructive" : "default"}
               onClick={() => setIsVoiceActive(!isVoiceActive)}
@@ -93,15 +101,17 @@ export default function AIAssistantPage() {
               {isVoiceActive ? <PhoneOff className="h-4 w-4" /> : <Phone className="h-4 w-4" />}
               {isVoiceActive ? "End Voice Call" : "Start Voice Call"}
             </Button>
-            <Button variant="outline" size="icon" onClick={() => setIsMicOn(!isMicOn)}>
-              {isMicOn ? <Mic className="h-4 w-4" /> : <MicOff className="h-4 w-4" />}
-            </Button>
-            <Button variant="outline" size="icon" onClick={() => setIsSpeakerOn(!isSpeakerOn)}>
-              {isSpeakerOn ? <Volume2 className="h-4 w-4" /> : <VolumeX className="h-4 w-4" />}
-            </Button>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" size="icon" onClick={() => setIsMicOn(!isMicOn)}>
+                {isMicOn ? <Mic className="h-4 w-4" /> : <MicOff className="h-4 w-4" />}
+              </Button>
+              <Button variant="outline" size="icon" onClick={() => setIsSpeakerOn(!isSpeakerOn)}>
+                {isSpeakerOn ? <Volume2 className="h-4 w-4" /> : <VolumeX className="h-4 w-4" />}
+              </Button>
+            </div>
           </div>
-        </div>
-      </header>
+        }
+      />
 
       <div className="flex-1 container py-6">
         <div className="grid gap-6 lg:grid-cols-4">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -44,10 +44,11 @@ import ProjectCard from "@/components/project-card";
 import RecentActivity from "@/components/recent-activity";
 import QuickStats from "@/components/quick-stats";
 import dynamic from "next/dynamic";
-import { SidebarTrigger } from "@/components/ui/sidebar";
 import { supabase } from "@/lib/supabaseClient";
 import { Project, Activity, RawActivity } from "@/lib/types";
 import { toast } from "@/hooks/use-toast";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { PageHeader } from "@/components/PageHeader";
 
 const STATUS_OPTIONS = ["active", "planning", "completed", "archived"] as const;
 
@@ -484,65 +485,29 @@ export default function DashboardPage() {
     return matchesSearch && matchesFilter;
   });
 
+  const activeProjectsCount = projects.filter((p) => p.status === "active").length;
+  const collaborativeProjectsCount = projects.filter((p) => p.collaborators > 1).length;
+
   return (
     <div className="flex flex-col min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b bg-background/95 backdrop-blur">
-        <div className="container flex h-16 items-center justify-between">
-          <div className="flex items-center gap-2">
-            <SidebarTrigger />
-            <div className="flex items-center">
-              <svg
-                width="32"
-                height="32"
-                viewBox="0 0 32 32"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                className="mr-2"
-              >
-                <path
-                  d="M8 6C8 4.89543 8.89543 4 10 4H22C23.1046 4 24 4.89543 24 6V26C24 27.1046 23.1046 28 22 28H10C8.89543 28 8 27.1046 8 26V6Z"
-                  fill="#FF5722"
-                />
-                <path
-                  d="M14 10L18 14M18 10L14 14"
-                  stroke="#0D47A1"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-                <path
-                  d="M14 18L18 22M18 18L14 22"
-                  stroke="#0D47A1"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-              </svg>
-              <span className="text-xl font-bold text-primary">CodeJoin</span>
-            </div>
-          </div>
-          <div className="flex items-center gap-4">
-            <Link href="./new-project">
-              <Button>
+      <PageHeader
+        leading={<SidebarTrigger />}
+        trailing={
+          <>
+            <Link href="/new-project">
+              <Button size="sm">
                 <Plus className="h-4 w-4 mr-2" />
                 New Project
               </Button>
             </Link>
             <UserDropdown />
-          </div>
-        </div>
-      </header>
+          </>
+        }
+        title={userName ? `Welcome back, ${userName}!` : "Welcome back!"}
+        description={`You have ${activeProjectsCount} active projects and ${collaborativeProjectsCount} collaborative projects.`}
+      />
 
       <div className="flex-1 container py-6">
-        {/* Welcome Section */}
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold mb-2">Welcome back, {userName}!</h1>
-          <p className="text-muted-foreground">
-            You have {projects.filter((p) => p.status === "active").length}{" "}
-            active projects and{" "}
-            {projects.filter((p) => p.collaborators > 1).length} collaborative
-            projects.
-          </p>
-        </div>
 
         {/* Quick Stats */}
         <QuickStats projects={projects} />

--- a/app/new-project/page.tsx
+++ b/app/new-project/page.tsx
@@ -35,6 +35,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabaseClient";
 import { TemplateNode } from "@/lib/types";
+import { PageHeader } from "@/components/PageHeader";
 
 const projectTemplates = [
   // --- Core Programming Languages (Backend Supported) ---
@@ -393,48 +394,26 @@ export default function NewProjectPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b bg-background/95 backdrop-blur">
-        <div className="container flex h-16 items-center justify-between">
-          <div className="flex items-center gap-4">
-            <Link href="/dashboard">
-              <Button variant="ghost" size="sm">
-                <ArrowLeft className="h-4 w-4 mr-2" />
-              </Button>
-            </Link>
-            <Separator orientation="vertical" className="h-6" />
-            <div className="flex items-center gap-2">
-              <svg
-                width="24"
-                height="24"
-                viewBox="0 0 32 32"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 6C8 4.89543 8.89543 4 10 4H22C23.1046 4 24 4.89543 24 6V26C24 27.1046 23.1046 28 22 28H10C8.89543 28 8 27.1046 8 26V6Z"
-                  fill="#FF5722"
-                />
-                <path
-                  d="M14 10L18 14M18 10L14 14"
-                  stroke="#0D47A1"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-                <path
-                  d="M14 18L18 22M18 18L14 22"
-                  stroke="#0D47A1"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-              </svg>
-              <span className="text-lg font-bold text-primary">CodeJoin</span>
-            </div>
-          </div>
-          <h1 className="text-xl font-semibold">Create New Project</h1>
-          <div className="w-32" /> {/* Spacer for centering */}
-        </div>
-      </header>
+      <PageHeader
+        leading={
+          <Link href="/dashboard">
+            <Button variant="ghost" size="sm" className="gap-2">
+              <ArrowLeft className="h-4 w-4" />
+              Back
+            </Button>
+          </Link>
+        }
+        startContent={
+          <>
+            <Separator orientation="vertical" className="hidden h-6 sm:block" />
+            <span className="hidden text-sm font-medium text-muted-foreground sm:inline">
+              Project setup
+            </span>
+          </>
+        }
+        title="Create a new project"
+        description="Start from a template, import from GitHub, or configure everything manually."
+      />
 
       <div className="container py-8 max-w-4xl">
         <div className="space-y-8">

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -48,6 +48,7 @@ import {
   X,
 } from "lucide-react";
 import Link from "next/link";
+import { PageHeader } from "@/components/PageHeader";
 
 const teams = [
   {
@@ -195,110 +196,59 @@ export default function TeamsPage() {
 
   return (
     <div className="flex flex-col min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b bg-background/95 backdrop-blur">
-        <div className="container flex h-16 items-center justify-between">
-          <div className="flex items-center gap-2">
-            <div className="flex items-center">
-              <svg
-                width="32"
-                height="32"
-                viewBox="0 0 32 32"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                className="mr-2"
-              >
-                <path
-                  d="M8 6C8 4.89543 8.89543 4 10 4H22C23.1046 4 24 4.89543 24 6V26C24 27.1046 23.1046 28 22 28H10C8.89543 28 8 27.1046 8 26V6Z"
-                  fill="#FF5722"
-                />
-                <path
-                  d="M14 10L18 14M18 10L14 14"
-                  stroke="#0D47A1"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-                <path
-                  d="M14 18L18 22M18 18L14 22"
-                  stroke="#0D47A1"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-              </svg>
-              <span className="text-xl font-bold text-primary">CodeJoin</span>
-            </div>
+      <PageHeader
+        title="Teams"
+        description="Organize your collaborators, assign roles, and keep every project team aligned in CodeJoin."
+        startContent={
+          <div className="hidden items-center gap-2 text-sm font-medium text-muted-foreground sm:flex">
+            <Users className="h-4 w-4" />
+            Collaboration hub
           </div>
-          <nav className="hidden md:flex items-center gap-6">
-            <Link
-              href="/dashboard"
-              className="text-sm font-medium hover:underline underline-offset-4"
-            >
-              Dashboard
-            </Link>
-            <Link
-              href="/templates"
-              className="text-sm font-medium hover:underline underline-offset-4"
-            >
-              Templates
-            </Link>
-            <Link href="/teams" className="text-sm font-medium text-primary">
-              Teams
-            </Link>
-            <Link
-              href="/settings"
-              className="text-sm font-medium hover:underline underline-offset-4"
-            >
-              Settings
-            </Link>
-          </nav>
-          <div className="flex items-center gap-4">
-            <Dialog open={isCreateTeamOpen} onOpenChange={setIsCreateTeamOpen}>
-              <DialogTrigger asChild>
-                <Button>
-                  <Plus className="h-4 w-4 mr-2" />
-                  Create Team
-                </Button>
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Create New Team</DialogTitle>
-                </DialogHeader>
-                <div className="space-y-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="team-name">Team Name</Label>
-                    <Input
-                      id="team-name"
-                      placeholder="Enter team name"
-                      value={newTeamName}
-                      onChange={(e) => setNewTeamName(e.target.value)}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="team-description">Description</Label>
-                    <Textarea
-                      id="team-description"
-                      placeholder="Describe your team's purpose"
-                      value={newTeamDescription}
-                      onChange={(e) => setNewTeamDescription(e.target.value)}
-                    />
-                  </div>
-                  <div className="flex justify-end gap-2">
-                    <Button
-                      variant="outline"
-                      onClick={() => setIsCreateTeamOpen(false)}
-                    >
-                      Cancel
-                    </Button>
-                    <Button onClick={handleCreateTeam} disabled={!newTeamName}>
-                      Create Team
-                    </Button>
-                  </div>
+        }
+        actions={
+          <Dialog open={isCreateTeamOpen} onOpenChange={setIsCreateTeamOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm" className="gap-2">
+                <Plus className="h-4 w-4" />
+                Create Team
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Create New Team</DialogTitle>
+              </DialogHeader>
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="team-name">Team Name</Label>
+                  <Input
+                    id="team-name"
+                    placeholder="Enter team name"
+                    value={newTeamName}
+                    onChange={(e) => setNewTeamName(e.target.value)}
+                  />
                 </div>
-              </DialogContent>
-            </Dialog>
-          </div>
-        </div>
-      </header>
+                <div className="space-y-2">
+                  <Label htmlFor="team-description">Description</Label>
+                  <Textarea
+                    id="team-description"
+                    placeholder="Describe your team's purpose"
+                    value={newTeamDescription}
+                    onChange={(e) => setNewTeamDescription(e.target.value)}
+                  />
+                </div>
+                <div className="flex justify-end gap-2">
+                  <Button variant="outline" onClick={() => setIsCreateTeamOpen(false)}>
+                    Cancel
+                  </Button>
+                  <Button onClick={handleCreateTeam} disabled={!newTeamName}>
+                    Create Team
+                  </Button>
+                </div>
+              </div>
+            </DialogContent>
+          </Dialog>
+        }
+      />
 
       <div className="flex-1 container py-6">
         <div className="grid gap-6 lg:grid-cols-4">

--- a/app/templates-section/page.tsx
+++ b/app/templates-section/page.tsx
@@ -17,8 +17,8 @@ import {
 } from "lucide-react";
 import TemplateCard from "@/components/template-card";
 import TemplatePreview from "@/components/template-preview";
-import NavLinks from "@/components/nav-links";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { PageHeader } from "@/components/PageHeader";
 
 export default function TemplatesPage() {
   const [searchQuery, setSearchQuery] = useState("");
@@ -133,31 +133,34 @@ export default function TemplatesPage() {
 
   return (
     <div className="flex flex-col min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b bg-background/95 backdrop-blur">
-        <div className="container flex h-16 items-center justify-between">
-          <div className="flex items-center gap-2">
-            <SidebarTrigger />
-            <Code className="h-6 w-6 text-primary" />
-            <h1 className="text-xl font-bold">Templates</h1>
+      <PageHeader
+        leading={<SidebarTrigger />}
+        startContent={
+          <div className="hidden items-center gap-2 text-sm font-medium text-muted-foreground sm:flex">
+            <Code className="h-4 w-4" />
+            Template library
           </div>
-          <div className="flex items-center gap-4">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        }
+        title="Templates"
+        description="Browse curated starter kits for web, mobile, and backend projects. Preview, customize, and launch in minutes."
+        actions={
+          <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+            <div className="relative w-full sm:w-72">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input
                 placeholder="Search templates..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-10 w-64"
+                className="pl-10"
               />
             </div>
-            <Button>
-              <Download className="h-4 w-4 mr-2" />
-              Upload Template
+            <Button className="w-full sm:w-auto">
+              <Download className="h-4 w-4" />
+              <span className="ml-2">Upload Template</span>
             </Button>
           </div>
-        </div>
-      </header>
+        }
+      />
 
       <div className="flex-1 container py-6">
         {/* Featured Templates */}

--- a/components/LogoMark.tsx
+++ b/components/LogoMark.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export function LogoMark({ className, ...props }: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("h-8 w-8", className)}
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M8 6C8 4.89543 8.89543 4 10 4H22C23.1046 4 24 4.89543 24 6V26C24 27.1046 23.1046 28 22 28H10C8.89543 28 8 27.1046 8 26V6Z"
+        fill="#FF5722"
+      />
+      <path
+        d="M14 10L18 14M18 10L14 14"
+        stroke="#0D47A1"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M14 18L18 22M18 18L14 22"
+        stroke="#0D47A1"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/components/PageHeader.tsx
+++ b/components/PageHeader.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { LogoMark } from "@/components/LogoMark";
+
+interface PageHeaderProps {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  leading?: React.ReactNode;
+  startContent?: React.ReactNode;
+  trailing?: React.ReactNode;
+  actions?: React.ReactNode;
+  children?: React.ReactNode;
+  hideLogo?: boolean;
+  className?: string;
+}
+
+export function PageHeader({
+  title,
+  description,
+  leading,
+  startContent,
+  trailing,
+  actions,
+  children,
+  hideLogo = false,
+  className,
+}: PageHeaderProps) {
+  const showSecondaryRow = Boolean(title || description || actions || children);
+
+  return (
+    <header
+      className={cn(
+        "border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60",
+        className,
+      )}
+    >
+      <div className="container flex h-16 items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          {leading}
+          {!hideLogo && (
+            <Link href="/dashboard" className="flex items-center gap-2 text-foreground">
+              <LogoMark className="h-6 w-6" />
+              <span className="text-sm font-semibold">CodeJoin</span>
+            </Link>
+          )}
+          {startContent}
+        </div>
+        <div className={cn("flex items-center gap-2", !trailing && "min-h-[1.5rem]")}>{trailing}</div>
+      </div>
+      {showSecondaryRow && (
+        <div className="border-t">
+          <div className="container py-6">
+            <div
+              className={cn(
+                "flex flex-col gap-4",
+                actions && "md:flex-row md:items-center md:justify-between",
+              )}
+            >
+              <div className="space-y-1">
+                {typeof title === "string" ? (
+                  <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+                ) : (
+                  title
+                )}
+                {typeof description === "string" ? (
+                  <p className="text-muted-foreground">{description}</p>
+                ) : (
+                  description
+                )}
+              </div>
+              {actions}
+            </div>
+            {children ? <div className="mt-6">{children}</div> : null}
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add shared LogoMark and PageHeader components to standardize header layout
- update dashboard, new project, templates, teams, and AI assistant routes to use the new header with page-specific context

## Testing
- npm run lint *(fails: ESLint must be installed; npm install --save-dev eslint blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d50eec897c83329561604d6eebfec3