### PR TITLE
feat: wire terminal to sandbox

### DIFF
--- a/lib/socket.tsx
+++ b/lib/socket.tsx
@@ -19,6 +19,9 @@ interface SocketContextType {
   emitCursorPosition: (data: { projectId: string; fileId: string; position: any; userId: string }) => void
   emitFileSelect: (data: { projectId: string; fileId: string; userId: string }) => void
   emitExecutionResult: (data: { projectId: string; fileId: string; result: any; userId: string }) => void
+  startTerminalSession: (data: { projectId: string; userId: string; language?: string }) => void
+  sendTerminalInput: (data: { sessionId: string; input: string }) => void
+  stopTerminalSession: (data: { sessionId: string }) => void
   collaborators: Array<{
     userId: string
     userName: string
@@ -37,6 +40,9 @@ const SocketContext = createContext<SocketContextType>({
   emitCursorPosition: () => {},
   emitFileSelect: () => {},
   emitExecutionResult: () => {},
+  startTerminalSession: () => {},
+  sendTerminalInput: () => {},
+  stopTerminalSession: () => {},
   collaborators: []
 })
 
@@ -177,6 +183,24 @@ export const SocketProvider = ({ children }: SocketProviderProps) => {
     }
   }, [socket])
 
+  const startTerminalSession = useCallback((data: { projectId: string; userId: string; language?: string }) => {
+    if (socket) {
+      socket.emit('terminal:start', data)
+    }
+  }, [socket])
+
+  const sendTerminalInput = useCallback((data: { sessionId: string; input: string }) => {
+    if (socket) {
+      socket.emit('terminal:input', data)
+    }
+  }, [socket])
+
+  const stopTerminalSession = useCallback((data: { sessionId: string }) => {
+    if (socket) {
+      socket.emit('terminal:stop', data)
+    }
+  }, [socket])
+
   return (
     <SocketContext.Provider value={{
       socket,
@@ -187,6 +211,9 @@ export const SocketProvider = ({ children }: SocketProviderProps) => {
       emitCursorPosition,
       emitFileSelect,
       emitExecutionResult,
+      startTerminalSession,
+      sendTerminalInput,
+      stopTerminalSession,
       collaborators
     }}>
       {children}


### PR DESCRIPTION
## Summary
- add socket helpers for starting, streaming, and stopping terminal sessions
- refactor the terminal panel to stream PTY data and manage session lifecycle from the UI
- expose terminal session management on the server backed by interactive Docker containers

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d612e7d3a08332a8064640fd284b06