### PR TITLE
fix: support raw terminal payloads

### DIFF
--- a/lib/socket.tsx
+++ b/lib/socket.tsx
@@ -47,7 +47,10 @@ interface SocketContextType {
     userId: string;
     language?: string;
   }) => void;
-  sendTerminalInput: (data: { sessionId: string; input: string }) => void;
+  sendTerminalInput: (data: {
+    sessionId: string;
+    input: string | ArrayBuffer | Uint8Array;
+  }) => void;
   stopTerminalSession: (data: { sessionId: string }) => void;
   collaborators: Array<{
     userId: string;
@@ -264,7 +267,10 @@ export const SocketProvider = ({ children }: SocketProviderProps) => {
   );
 
   const sendTerminalInput = useCallback(
-    (data: { sessionId: string; input: string }) => {
+    (data: {
+      sessionId: string;
+      input: string | ArrayBuffer | Uint8Array;
+    }) => {
       if (socket) {
         socket.emit("terminal:input", data);
       }


### PR DESCRIPTION
## Summary
- update `normalizeTerminalInput` to accept buffers, preserve control sequences, and fall back to CR injection only when strings lack control characters
- write binary socket payloads directly to the Docker stream when they arrive from Socket.IO
- expand the socket helper so upcoming terminal components can emit `Uint8Array`/`ArrayBuffer` payloads without string conversion

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68dc97ff33f8833297485598e7914c8e