### PR TITLE
fix: stabilize terminal selection handling

### DIFF
--- a/components/terminal/TerminalSurface.tsx
+++ b/components/terminal/TerminalSurface.tsx
@@ -31,7 +31,15 @@ interface TerminalSurfaceProps {
 }
 
 const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
-  ({ className, onReady, onData, onError, onExit, onUserInput }, ref) => {
+  ({
+    className,
+    onReady,
+    onData,
+    onInput,
+    onError,
+    onExit,
+    onUserInput,
+  }, ref) => {
     const { socket, sendTerminalInput } = useSocket();
 
     const containerRef = useRef<HTMLDivElement | null>(null);
@@ -40,6 +48,18 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
     const activeSessionIdRef = useRef<string | null>(null);
     const resizeObserverRef = useRef<ResizeObserver | null>(null);
     const inputListenerRef = useRef<IDisposable | null>(null);
+    const onInputRef = useRef<TerminalSurfaceProps["onInput"] | null>(
+      onInput ?? null
+    );
+    const sendTerminalInputRef = useRef(sendTerminalInput);
+
+    useEffect(() => {
+      onInputRef.current = onInput ?? null;
+    }, [onInput]);
+
+    useEffect(() => {
+      sendTerminalInputRef.current = sendTerminalInput;
+    }, [sendTerminalInput]);
 
     useEffect(() => {
       const terminal = new Terminal({
@@ -53,7 +73,7 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
           background: "#1e1e1e",
           foreground: "#cccccc",
           cursor: "#4ec9b0",
-          selection: "rgba(78, 201, 176, 0.3)",
+          selectionBackground: "rgba(78, 201, 176, 0.3)",
         },
       });
 
@@ -94,7 +114,7 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
           return;
         }
 
-        sendTerminalInputRef.current({ sessionId, input: outbound });
+        sendTerminalInputRef.current?.({ sessionId, input: outbound });
       };
 
       if (containerRef.current) {


### PR DESCRIPTION
## Summary
- add refs for socket input handlers to resolve missing identifiers and keep callbacks stable
- update the xterm theme selection color to use a supported option that removes the stray white selection band

## Testing
- npm run lint *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb9e602b88332bfed9ec082d5eb47