### PR TITLE
fix: improve terminal fit handling

### DIFF
--- a/components/terminal/TerminalSurface.tsx
+++ b/components/terminal/TerminalSurface.tsx
@@ -2,7 +2,13 @@
 
 import "xterm/css/xterm.css";
 
-import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from "react";
 import { Terminal, type IDisposable } from "xterm";
 import { FitAddon } from "xterm-addon-fit";
 import { WebLinksAddon } from "xterm-addon-web-links";
@@ -42,7 +48,7 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
     { className, onReady, onData, onInput, onError, onExit, onUserInput },
     ref
   ) => {
-    const { socket, sendTerminalInput } = useSocket();
+    const { socket, sendTerminalInput, emitTerminalResize } = useSocket();
 
     const containerRef = useRef<HTMLDivElement | null>(null);
     const terminalRef = useRef<Terminal | null>(null);
@@ -54,6 +60,82 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
       onInput ?? null
     );
     const sendTerminalInputRef = useRef(sendTerminalInput);
+    const emitTerminalResizeRef = useRef(emitTerminalResize);
+    const pendingFitFrameRef = useRef<number | null>(null);
+    const lastMeasuredDimensionsRef = useRef<
+      | {
+          width: number;
+          height: number;
+        }
+      | null
+    >(null);
+    const lastKnownGeometryRef = useRef<
+      | {
+          cols: number;
+          rows: number;
+        }
+      | null
+    >(null);
+
+    const runFitAndEmit = useCallback(() => {
+      pendingFitFrameRef.current = null;
+
+      const container = containerRef.current;
+      const fitAddon = fitAddonRef.current;
+      const terminal = terminalRef.current;
+
+      if (!container || !fitAddon || !terminal) {
+        return;
+      }
+
+      const width = container.clientWidth;
+      const height = container.clientHeight;
+
+      if (width === 0 || height === 0) {
+        return;
+      }
+
+      try {
+        fitAddon.fit();
+      } catch (error) {
+        console.warn("Failed to fit terminal dimensions", error);
+        return;
+      }
+
+      lastMeasuredDimensionsRef.current = { width, height };
+
+      const cols = terminal.cols;
+      const rows = terminal.rows;
+
+      const lastGeometry = lastKnownGeometryRef.current;
+      if (lastGeometry && lastGeometry.cols === cols && lastGeometry.rows === rows) {
+        return;
+      }
+
+      lastKnownGeometryRef.current = { cols, rows };
+
+      const sessionId = activeSessionIdRef.current;
+      const emit = emitTerminalResizeRef.current;
+
+      if (!sessionId || !emit) {
+        return;
+      }
+
+      emit({ sessionId, cols, rows });
+    }, []);
+
+    const scheduleFitAndEmit = useCallback(() => {
+      if (pendingFitFrameRef.current !== null) {
+        return;
+      }
+
+      if (typeof window === "undefined" || !window.requestAnimationFrame) {
+        runFitAndEmit();
+        return;
+      }
+
+      pendingFitFrameRef.current = window.requestAnimationFrame(runFitAndEmit);
+    }, [runFitAndEmit]);
 
     useEffect(() => {
       onInputRef.current = onInput ?? null;
@@ -62,6 +144,10 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
     useEffect(() => {
       sendTerminalInputRef.current = sendTerminalInput;
     }, [sendTerminalInput]);
+
+    useEffect(() => {
+      emitTerminalResizeRef.current = emitTerminalResize;
+    }, [emitTerminalResize]);
 
     useEffect(() => {
       const terminal = new Terminal({
@@ -87,13 +173,53 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
       terminal.loadAddon(webLinksAddon);
       terminal.loadAddon(clipboardAddon);
 
-      const resizeObserver = new ResizeObserver(() => {
-        try {
-          fitAddon.fit();
-        } catch (error) {
-          console.warn("Failed to fit terminal on resize", error);
+      const resizeObserver = new ResizeObserver((entries) => {
+        const container = containerRef.current;
+        if (!container) {
+          return;
+        }
+
+        let shouldSchedule = false;
+        for (const entry of entries) {
+          if (entry.target !== container && entry.target !== container.parentElement) {
+            continue;
+          }
+
+          if (entry.target === container) {
+            const boxSize = Array.isArray(entry.contentBoxSize)
+              ? entry.contentBoxSize[0]
+              : entry.contentBoxSize;
+            const width =
+              typeof boxSize?.inlineSize === "number"
+                ? boxSize.inlineSize
+                : entry.contentRect.width;
+            const height =
+              typeof boxSize?.blockSize === "number"
+                ? boxSize.blockSize
+                : entry.contentRect.height;
+
+            if (typeof width === "number" && typeof height === "number") {
+              const last = lastMeasuredDimensionsRef.current;
+              if (last && last.width === width && last.height === height) {
+                continue;
+              }
+              lastMeasuredDimensionsRef.current = { width, height };
+            }
+          }
+
+          shouldSchedule = true;
+        }
+
+        if (shouldSchedule) {
+          scheduleFitAndEmit();
         }
       });
+      const handleWindowResize = () => {
+        scheduleFitAndEmit();
+      };
+      if (typeof window !== "undefined") {
+        window.addEventListener("resize", handleWindowResize);
+      }
 
       let dataDisposable: IDisposable | undefined;
       let binaryDisposable: IDisposable | undefined;
@@ -126,12 +252,16 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
         terminal.focus();
         queueMicrotask(() => {
           try {
-            fitAddon.fit();
+            scheduleFitAndEmit();
           } catch (error) {
             console.warn("Failed to fit terminal on mount", error);
           }
         });
         resizeObserver.observe(containerRef.current);
+        const parentElement = containerRef.current.parentElement;
+        if (parentElement) {
+          resizeObserver.observe(parentElement);
+        }
       }
 
       terminalRef.current = terminal;
@@ -142,6 +272,17 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
         dataDisposable?.dispose();
         binaryDisposable?.dispose();
         resizeObserver.disconnect();
+        if (typeof window !== "undefined") {
+          window.removeEventListener("resize", handleWindowResize);
+        }
+        if (pendingFitFrameRef.current !== null) {
+          if (typeof window !== "undefined" && window.cancelAnimationFrame) {
+            window.cancelAnimationFrame(pendingFitFrameRef.current);
+          }
+          pendingFitFrameRef.current = null;
+        }
+        lastMeasuredDimensionsRef.current = null;
+        lastKnownGeometryRef.current = null;
         clipboardAddon.dispose?.();
         webLinksAddon.dispose?.();
         inputListenerRef.current?.dispose();
@@ -151,7 +292,7 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
         fitAddonRef.current = null;
         resizeObserverRef.current = null;
       };
-    }, []);
+    }, [scheduleFitAndEmit]);
 
     useEffect(() => {
       if (!terminalRef.current) {
@@ -186,12 +327,9 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
 
       const handleReady = (payload: { sessionId: string }) => {
         activeSessionIdRef.current = payload.sessionId;
+        lastKnownGeometryRef.current = null;
         queueMicrotask(() => {
-          try {
-            fitAddonRef.current?.fit();
-          } catch (error) {
-            console.warn("Failed to fit terminal after ready", error);
-          }
+          scheduleFitAndEmit();
         });
         onReady?.(payload);
       };
@@ -236,6 +374,7 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
           return;
         }
         activeSessionIdRef.current = null;
+        lastKnownGeometryRef.current = null;
         onExit?.(payload);
       };
 
@@ -250,7 +389,7 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
         socket.off("terminal:error", handleError);
         socket.off("terminal:exit", handleExit);
       };
-    }, [socket, onReady, onData, onError, onExit]);
+    }, [socket, onReady, onData, onError, onExit, scheduleFitAndEmit]);
 
     useImperativeHandle(
       ref,


### PR DESCRIPTION
## Summary
- debounce terminal fitting with requestAnimationFrame and skip redundant socket emissions when geometry is unchanged
- observe the terminal container, its parent, and window resize events to re-fit when the panel is resized
- reset cached geometry between sessions so new sessions immediately broadcast their dimensions

## Testing
- npm run lint *(fails: Missing ESLint config "next/core-web-vitals" in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc7733c148332a4c2389bcfd80339