### PR TITLE
fix: buffer terminal input before session activation

### DIFF
--- a/components/terminal/TerminalSurface.tsx
+++ b/components/terminal/TerminalSurface.tsx
@@ -54,6 +54,7 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
     const terminalRef = useRef<Terminal | null>(null);
     const fitAddonRef = useRef<FitAddon | null>(null);
     const activeSessionIdRef = useRef<string | null>(null);
+    const pendingInputRef = useRef<string[]>([]);
     const resizeObserverRef = useRef<ResizeObserver | null>(null);
     const inputListenerRef = useRef<IDisposable | null>(null);
     const onInputRef = useRef<TerminalSurfaceProps["onInput"] | null>(
@@ -76,6 +77,26 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
         }
       | null
     >(null);
+
+    const dispatchInput = useCallback((sessionId: string, chunk: string) => {
+      if (!chunk) {
+        return;
+      }
+
+      const processed = onInputRef.current?.({ sessionId, input: chunk });
+
+      if (processed === null) {
+        return;
+      }
+
+      const outbound = typeof processed === "string" ? processed : chunk;
+
+      if (!outbound) {
+        return;
+      }
+
+      sendTerminalInputRef.current?.({ sessionId, input: outbound });
+    }, []);
 
     const runFitAndEmit = useCallback(() => {
       pendingFitFrameRef.current = null;
@@ -224,25 +245,17 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
       let dataDisposable: IDisposable | undefined;
       let binaryDisposable: IDisposable | undefined;
 
-      const handleInput = (input: string) => {
+      const handleInput = (chunk: string) => {
+        if (!chunk) {
+          return;
+        }
         const sessionId = activeSessionIdRef.current;
         if (!sessionId) {
+          pendingInputRef.current.push(chunk);
           return;
         }
 
-        const processed = onInputRef.current?.({ sessionId, input });
-
-        if (processed === null) {
-          return;
-        }
-
-        const outbound = typeof processed === "string" ? processed : input;
-
-        if (!outbound) {
-          return;
-        }
-
-        sendTerminalInputRef.current?.({ sessionId, input: outbound });
+        dispatchInput(sessionId, chunk);
       };
 
       if (containerRef.current) {
@@ -292,7 +305,7 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
         fitAddonRef.current = null;
         resizeObserverRef.current = null;
       };
-    }, [scheduleFitAndEmit]);
+    }, [scheduleFitAndEmit, dispatchInput]);
 
     useEffect(() => {
       if (!terminalRef.current) {
@@ -328,6 +341,12 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
       const handleReady = (payload: { sessionId: string }) => {
         activeSessionIdRef.current = payload.sessionId;
         lastKnownGeometryRef.current = null;
+        if (pendingInputRef.current.length > 0) {
+          for (const chunk of pendingInputRef.current) {
+            dispatchInput(payload.sessionId, chunk);
+          }
+          pendingInputRef.current = [];
+        }
         queueMicrotask(() => {
           scheduleFitAndEmit();
         });
@@ -375,6 +394,7 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
         }
         activeSessionIdRef.current = null;
         lastKnownGeometryRef.current = null;
+        pendingInputRef.current = [];
         onExit?.(payload);
       };
 
@@ -389,7 +409,15 @@ const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
         socket.off("terminal:error", handleError);
         socket.off("terminal:exit", handleExit);
       };
-    }, [socket, onReady, onData, onError, onExit, scheduleFitAndEmit]);
+    }, [
+      socket,
+      onReady,
+      onData,
+      onError,
+      onExit,
+      scheduleFitAndEmit,
+      dispatchInput,
+    ]);
 
     useImperativeHandle(
       ref,


### PR DESCRIPTION
## Summary
- add a pending input buffer to capture keystrokes before the terminal session becomes ready
- centralize input dispatch logic to reuse filtering and outbound sending across listeners
- flush buffered input once a session id is known and clear buffers on exit to avoid stale replays

## Testing
- npm run lint *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68dccf33b8688332a8b41865f17d5165