### PR TITLE
fix: ensure terminal fallbacks include languages

### DIFF
--- a/components/project-workspace.tsx
+++ b/components/project-workspace.tsx
@@ -878,20 +878,26 @@ function TerminalPanel({
         const resolvedModule = module ?? (await loadCodeExecutionModule());
         const response = await resolvedModule.codeExecutionAPI.getSupportedLanguages();
         const keys = new Set<string>();
+        let hasCatalogEntries = false;
 
         if (response.success && Array.isArray(response.languages)) {
           response.languages.forEach((languageConfig) => {
             if (languageConfig?.id) {
               keys.add(languageConfig.id.toLowerCase());
+              hasCatalogEntries = true;
             }
           });
         }
 
-        // Always treat JavaScript as the default fallback runtime.
-        keys.add("javascript");
-
-        supportedLanguageKeysRef.current =
-          keys.size > 0 ? keys : new Set(SAFE_TERMINAL_LANGUAGE_FALLBACKS);
+        if (hasCatalogEntries) {
+          // Always treat JavaScript as the default fallback runtime.
+          keys.add("javascript");
+          supportedLanguageKeysRef.current = keys;
+        } else {
+          supportedLanguageKeysRef.current = new Set(
+            SAFE_TERMINAL_LANGUAGE_FALLBACKS
+          );
+        }
       } catch (error) {
         console.warn("Failed to load supported terminal languages", error);
         supportedLanguageKeysRef.current = new Set(


### PR DESCRIPTION
## Summary
- set the cached terminal language keys to SAFE_TERMINAL_LANGUAGE_FALLBACKS when the catalog call returns no languages
- keep JavaScript in the cache only when the catalog succeeds so non-JS fallbacks are preserved

## Testing
- npm run lint *(fails: missing next/core-web-vitals ESLint config in the container)*
- node <<'NODE' ... *(simulated catalog failure to confirm fallback languages)*

------
https://chatgpt.com/codex/tasks/task_e_68dd74e7d9b48332be19ced342334188