### PR TITLE
fix: reset terminal on disconnect

### DIFF
--- a/components/project-workspace.tsx
+++ b/components/project-workspace.tsx
@@ -211,6 +211,7 @@ function TerminalPanel({
   inputBuffer,
   onInputUpdate,
   onExecuteInTerminal,
+  terminalSurfaceRef: externalTerminalSurfaceRef,
 }: {
   projectId: string;
   userId: string;
@@ -221,6 +222,7 @@ function TerminalPanel({
   onExecuteInTerminal?: React.MutableRefObject<
     ((file: ProjectNodeFromDB) => Promise<boolean>) | null
   >;
+  terminalSurfaceRef?: React.MutableRefObject<TerminalSurfaceHandle | null>;
 }) {
   const { socket, isConnected, startTerminalSession, stopTerminalSession } =
     useSocket();
@@ -230,7 +232,9 @@ function TerminalPanel({
   const [isStarting, setIsStarting] = useState(false);
   const [isStopping, setIsStopping] = useState(false);
   const [sessionId, setSessionId] = useState<string | null>(null);
-  const terminalSurfaceRef = useRef<TerminalSurfaceHandle | null>(null);
+  const localTerminalSurfaceRef = useRef<TerminalSurfaceHandle | null>(null);
+  const terminalSurfaceRef =
+    externalTerminalSurfaceRef ?? localTerminalSurfaceRef;
   const sessionIdRef = useRef<string | null>(null);
   const isTerminalReadyRef = useRef(false);
   const activeLanguageRef = useRef<string | null>(null);
@@ -449,6 +453,25 @@ function TerminalPanel({
 
   type CommandAvailability = "available" | "missing" | "unknown";
 
+  const sendTerminalData = useCallback(
+    (payload: string, options?: { sessionId?: string }) => {
+      if (!isConnected) {
+        return;
+      }
+
+      const targetSessionId =
+        options?.sessionId ?? sessionIdRef.current ?? undefined;
+      if (!targetSessionId) {
+        return;
+      }
+
+      terminalSurfaceRef.current?.sendData(payload, {
+        sessionId: targetSessionId,
+      });
+    },
+    [isConnected, terminalSurfaceRef]
+  );
+
   const verifyCommandAvailability = useCallback(
     async (
       sessionId: string,
@@ -460,7 +483,7 @@ function TerminalPanel({
 
       const markerStartIndex = rawOutputBufferRef.current.length;
 
-      terminalSurfaceRef.current?.sendData(
+      sendTerminalData(
         `if command -v ${commandName} >/dev/null 2>&1; then echo '${successMarker}'; else echo '${failureMarker}'; fi\r`,
         { sessionId }
       );
@@ -479,7 +502,7 @@ function TerminalPanel({
         return "unknown";
       }
     },
-    [appendStatusLine, waitForTerminalMarker]
+    [appendStatusLine, sendTerminalData, waitForTerminalMarker]
   );
 
   type LanguageSupportResult = {
@@ -694,6 +717,24 @@ function TerminalPanel({
     [appendRawOutput]
   );
 
+  const resetSessionState = useCallback((reason?: string) => {
+    markerWatchersRef.current.forEach((watcher) =>
+      watcher.reject(new Error(reason || "Terminal session ended"))
+    );
+    markerWatchersRef.current = [];
+    hiddenMarkersRef.current.clear();
+    sessionIdRef.current = null;
+    setSessionId(null);
+    setIsTerminalReady(false);
+    isTerminalReadyRef.current = false;
+    setIsStarting(false);
+    setIsStopping(false);
+    activeLanguageRef.current = null;
+    pendingLanguageRef.current = null;
+    commandBufferRef.current = "";
+    commandHistoryRef.current = [];
+  }, []);
+
   const handleTerminalError = useCallback(
     ({
       sessionId: errorSessionId,
@@ -716,23 +757,9 @@ function TerminalPanel({
         description: message,
         variant: "destructive",
       });
-      markerWatchersRef.current.forEach((watcher) =>
-        watcher.reject(new Error(message))
-      );
-      markerWatchersRef.current = [];
-      hiddenMarkersRef.current.clear();
-      setIsTerminalReady(false);
-      isTerminalReadyRef.current = false;
-      setIsStarting(false);
-      setIsStopping(false);
-      sessionIdRef.current = null;
-      setSessionId(null);
-      activeLanguageRef.current = null;
-      pendingLanguageRef.current = null;
-      commandBufferRef.current = "";
-      commandHistoryRef.current = [];
+      resetSessionState(message);
     },
-    [appendStatusLine, toast]
+    [appendStatusLine, resetSessionState, toast]
   );
 
   const handleTerminalExit = useCallback(
@@ -758,23 +785,9 @@ function TerminalPanel({
       }
 
       appendStatusLine(exitMessageParts.join(" "));
-      markerWatchersRef.current.forEach((watcher) =>
-        watcher.reject(new Error(reason || "Terminal session ended"))
-      );
-      markerWatchersRef.current = [];
-      hiddenMarkersRef.current.clear();
-      sessionIdRef.current = null;
-      setSessionId(null);
-      setIsTerminalReady(false);
-      isTerminalReadyRef.current = false;
-      setIsStarting(false);
-      setIsStopping(false);
-      activeLanguageRef.current = null;
-      pendingLanguageRef.current = null;
-      commandBufferRef.current = "";
-      commandHistoryRef.current = [];
+      resetSessionState(reason);
     },
-    [appendStatusLine]
+    [appendStatusLine, resetSessionState]
   );
 
   useEffect(() => {
@@ -784,6 +797,23 @@ function TerminalPanel({
 
     hasShownConnectionMessage.current = true;
   }, [socket]);
+
+  useEffect(() => {
+    if (isConnected === false) {
+      if (sessionIdRef.current || isTerminalReadyRef.current) {
+        appendStatusLine(
+          "Lost connection to sandbox session. Resetting terminal state..."
+        );
+      }
+      resetSessionState("Terminal connection lost");
+      attemptedInitialStart.current = false;
+      return;
+    }
+
+    if (isConnected && !sessionIdRef.current) {
+      attemptedInitialStart.current = false;
+    }
+  }, [appendStatusLine, isConnected, resetSessionState]);
 
   // Cleanup active session when component unmounts
   useEffect(() => {
@@ -797,7 +827,7 @@ function TerminalPanel({
 
   // Execute code directly in the interactive terminal session
   const flushBufferedInput = useCallback(() => {
-    if (!sessionIdRef.current) return;
+    if (!isConnected || !sessionIdRef.current) return;
     const pendingInput = inputBuffer.replace(/\r/g, "");
     if (!pendingInput.trim()) return;
 
@@ -811,16 +841,14 @@ function TerminalPanel({
 
     lines.forEach((line, index) => {
       setTimeout(() => {
-        if (!sessionIdRef.current) return;
+        if (!isConnected || !sessionIdRef.current) return;
         const payload = line.length > 0 ? `${line}\r` : "\r";
-        terminalSurfaceRef.current?.sendData(payload, {
-          sessionId: sessionIdRef.current ?? undefined,
-        });
+        sendTerminalData(payload);
       }, 300 + index * 30);
     });
 
     onInputUpdate("");
-  }, [appendStatusLine, inputBuffer, onInputUpdate]);
+  }, [appendStatusLine, inputBuffer, isConnected, onInputUpdate, sendTerminalData]);
 
   const waitForTerminalReady = useCallback(async (timeoutMs = 10000) => {
     if (isTerminalReadyRef.current && sessionIdRef.current) {
@@ -1045,24 +1073,23 @@ function TerminalPanel({
           : null;
 
         if (directoryPath) {
-          terminalSurfaceRef.current?.sendData(`mkdir -p ${directoryPath}\r`, {
+          sendTerminalData(`mkdir -p ${directoryPath}\r`, {
             sessionId: activeSessionId,
           });
         }
 
-        terminalSurfaceRef.current?.sendData(
-          `cat <<'__CODEJOIN__' > ${filename}\r`,
-          { sessionId: activeSessionId }
-        );
+        sendTerminalData(`cat <<'__CODEJOIN__' > ${filename}\r`, {
+          sessionId: activeSessionId,
+        });
 
         lines.forEach((line) => {
           const sanitizedLine = line.replace(/\r/g, "");
-          terminalSurfaceRef.current?.sendData(`${sanitizedLine}\r`, {
+          sendTerminalData(`${sanitizedLine}\r`, {
             sessionId: activeSessionId,
           });
         });
 
-        terminalSurfaceRef.current?.sendData(`__CODEJOIN__\r`, {
+        sendTerminalData(`__CODEJOIN__\r`, {
           sessionId: activeSessionId,
         });
 
@@ -1097,7 +1124,7 @@ function TerminalPanel({
 
         appendStatusLine(`[run] ${runCommand}`);
 
-        terminalSurfaceRef.current?.sendData(`${runCommand}\r`, {
+        sendTerminalData(`${runCommand}\r`, {
           sessionId: activeSessionId,
         });
 
@@ -1130,6 +1157,7 @@ function TerminalPanel({
       ensureLanguageSupport,
       ensureSupportedLanguageKeys,
       loadCodeExecutionModule,
+      sendTerminalData,
     ]
   );
 
@@ -1515,6 +1543,7 @@ export default function ProjectWorkspace({
   const terminalExecutorWaitTimeoutRef = useRef<number | null>(null);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [inputBuffer, setInputBuffer] = useState("");
+  const terminalSurfaceRef = useRef<TerminalSurfaceHandle | null>(null);
 
   useEffect(() => {
     return () => {
@@ -2549,6 +2578,7 @@ export default function ProjectWorkspace({
                       inputBuffer={inputBuffer}
                       onInputUpdate={setInputBuffer}
                       onExecuteInTerminal={terminalExecuteCallbackRef}
+                      terminalSurfaceRef={terminalSurfaceRef}
                     />
                   </TabsContent>
 


### PR DESCRIPTION
## Summary
- centralize terminal session cleanup and reuse it on exit and error paths
- watch socket connectivity to reset state and re-trigger session provisioning on reconnect
- guard terminal send helpers from writing while disconnected to avoid buffering against dead sessions
- expose the terminal surface ref to the workspace and ensure the send helper is defined before command availability checks to avoid runtime errors

## Testing
- npm run lint *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68dddeddc4908332920f8298a5e3dc53