### PR TITLE
fix: auto recover from chunk load errors

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import Script from "next/script";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/toaster";
 import { AppLayout } from "@/components/app-layout";
@@ -24,6 +25,57 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
+        <Script id="next-chunk-recovery" strategy="beforeInteractive">
+          {`
+            (() => {
+              const STORAGE_KEY = 'next-chunk-retry-count';
+              const MAX_RETRIES = 3;
+
+              const handleChunkError = (event) => {
+                const target = event?.target;
+                if (!target || target.tagName !== 'SCRIPT') {
+                  return;
+                }
+
+                const src = target.src || '';
+                if (!src.includes('/_next/static/chunks/')) {
+                  return;
+                }
+
+                try {
+                  const retries = Number(sessionStorage.getItem(STORAGE_KEY) || '0');
+
+                  if (Number.isNaN(retries)) {
+                    sessionStorage.setItem(STORAGE_KEY, '1');
+                    window.location.reload();
+                    return;
+                  }
+
+                  if (retries >= MAX_RETRIES) {
+                    sessionStorage.removeItem(STORAGE_KEY);
+                    console.error('Chunk failed to load after multiple attempts.');
+                    return;
+                  }
+
+                  sessionStorage.setItem(STORAGE_KEY, String(retries + 1));
+                  window.location.reload();
+                } catch (storageError) {
+                  console.warn('Unable to persist chunk retry count', storageError);
+                  window.location.reload();
+                }
+              };
+
+              window.addEventListener('error', handleChunkError, true);
+              window.addEventListener('load', () => {
+                try {
+                  sessionStorage.removeItem(STORAGE_KEY);
+                } catch (storageError) {
+                  console.warn('Unable to reset chunk retry count', storageError);
+                }
+              });
+            })();
+          `}
+        </Script>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"


### PR DESCRIPTION
## Summary
- add a beforeInteractive script in the root layout to detect Next.js chunk load failures
- automatically retry loading the affected chunk up to three times and reset the retry tracker after a successful load

## Testing
- npm run lint *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68ddf9fc08d08332b0e3bf6f42c3145c