### PR TITLE
fix: harden chunk recovery script

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import Script from "next/script";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/toaster";
 import { AppLayout } from "@/components/app-layout";
@@ -24,6 +25,118 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
+        <Script id="next-chunk-recovery" strategy="beforeInteractive">
+          {`
+            (() => {
+              if (window.__NEXT_CHUNK_RECOVERY_INITIALIZED) {
+                return;
+              }
+
+              window.__NEXT_CHUNK_RECOVERY_INITIALIZED = true;
+
+              const STORAGE_KEY = 'next-chunk-retry-state';
+              const MAX_RETRIES = 3;
+              const CHUNK_PATH_PATTERN = /\/_next\/static\/(chunks|app|webpack)\//;
+
+              const readRetryState = () => {
+                try {
+                  const raw = sessionStorage.getItem(STORAGE_KEY);
+                  if (!raw) {
+                    return { count: 0 };
+                  }
+
+                  const parsed = JSON.parse(raw);
+                  if (!parsed || typeof parsed.count !== 'number' || Number.isNaN(parsed.count)) {
+                    return { count: 0 };
+                  }
+
+                  return { count: parsed.count };
+                } catch (error) {
+                  console.warn('Unable to read chunk retry state', error);
+                  return { count: 0 };
+                }
+              };
+
+              const persistRetryState = (state) => {
+                try {
+                  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+                } catch (error) {
+                  console.warn('Unable to persist chunk retry state', error);
+                }
+              };
+
+              const resetRetryState = () => {
+                try {
+                  sessionStorage.removeItem(STORAGE_KEY);
+                } catch (error) {
+                  console.warn('Unable to reset chunk retry state', error);
+                }
+              };
+
+              const reloadWithBuster = (retryCount) => {
+                const url = new URL(window.location.href);
+                url.searchParams.set('chunkRetry', String(retryCount));
+                url.searchParams.set('_ts', String(Date.now()));
+                window.location.replace(url.toString());
+              };
+
+              const scheduleRecoveryReload = () => {
+                const { count } = readRetryState();
+
+                if (count >= MAX_RETRIES) {
+                  resetRetryState();
+                  console.error('Chunk failed to load after multiple attempts.');
+                  return;
+                }
+
+                const nextCount = count + 1;
+                persistRetryState({ count: nextCount });
+                reloadWithBuster(nextCount);
+              };
+
+              const isChunkScript = (target) => {
+                if (!target || target.tagName !== 'SCRIPT') {
+                  return false;
+                }
+
+                const src = target.src || '';
+                return CHUNK_PATH_PATTERN.test(src);
+              };
+
+              const isChunkLoadError = (error) => {
+                if (!error) {
+                  return false;
+                }
+
+                const message = typeof error === 'string' ? error : error.message || '';
+                if (!message) {
+                  return false;
+                }
+
+                return message.includes('ChunkLoadError') || message.includes('Loading chunk');
+              };
+
+              const handleScriptError = (event) => {
+                if (isChunkScript(event?.target)) {
+                  scheduleRecoveryReload();
+                }
+              };
+
+              const handleUnhandledRejection = (event) => {
+                if (isChunkLoadError(event?.reason)) {
+                  event.preventDefault?.();
+                  scheduleRecoveryReload();
+                }
+              };
+
+              window.addEventListener('error', handleScriptError, true);
+              window.addEventListener('unhandledrejection', handleUnhandledRejection);
+              window.addEventListener('load', () => {
+                resetRetryState();
+              });
+            })();
+          `}
+        </Script>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"


### PR DESCRIPTION
## Summary
- guard the beforeInteractive chunk recovery initializer so it only registers once per session
- handle both script load errors and chunk promise rejections while cache busting reload attempts
- reset the retry state after a successful page load to avoid stale session storage entries

## Testing
- npm run lint *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68ddf9fc08d08332b0e3bf6f42c3145c