### PR TITLE
feat: set default project thumbnail for new projects

### DIFF
--- a/app/new-project/page.tsx
+++ b/app/new-project/page.tsx
@@ -26,6 +26,9 @@ type ProjectTemplate = StarterProject;
 
 const projectTemplates: ReadonlyArray<ProjectTemplate> = starterProjects;
 
+const DEFAULT_PROJECT_THUMBNAIL_URL =
+  "https://izngyuhawwlxopcdmfry.supabase.co/storage/v1/object/public/assets/project_placeholder.jpg";
+
 const languageOptions = starterProjectLanguages.map((language) => ({
   value: language.id,
   label: language.name,
@@ -110,6 +113,7 @@ export default function NewProjectPage() {
           tags: tags,
           language: template ? template.tags : [],
           status: "active",
+          thumbnail: template?.thumbnail ?? DEFAULT_PROJECT_THUMBNAIL_URL,
         })
         .select()
         .single();


### PR DESCRIPTION
## Summary
- set a default thumbnail URL when inserting new projects via Supabase
- centralize the placeholder image URL for reuse in the new project page

## Testing
- npm run lint *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa15eb29c8332a25e9ba584e95db6