### PR TITLE
fix: load collaborators from supabase

### DIFF
--- a/components/collaborators-list.tsx
+++ b/components/collaborators-list.tsx
@@ -1,37 +1,54 @@
 "use client";
 import { Users } from "lucide-react";
-import { type Collaborator } from "@/lib/types"; // 1. Import your database-driven type
+import { type Collaborator } from "@/lib/types";
 import { useSocket } from "@/lib/socket";
 
-// 2. Update the props interface to use the imported Collaborator type
+type RealtimeCollaborator = ReturnType<typeof useSocket>["collaborators"][number];
+type AnyCollaborator = Collaborator | RealtimeCollaborator;
+
 interface CollaboratorsListProps {
   collaborators?: Collaborator[];
-  projectId?: string;
 }
+
+const getCollaboratorId = (collaborator: AnyCollaborator) =>
+  "socketId" in collaborator ? collaborator.socketId : collaborator.user_id;
+
+const getCollaboratorAvatar = (collaborator: AnyCollaborator) => {
+  if ("userAvatar" in collaborator) {
+    return collaborator.userAvatar ?? "/placeholder.svg";
+  }
+
+  return collaborator.user_avatar ?? "/placeholder.svg";
+};
+
+const getCollaboratorName = (collaborator: AnyCollaborator) => {
+  if ("userName" in collaborator) {
+    return collaborator.userName || "Collaborator";
+  }
+
+  return collaborator.full_name ?? "Collaborator";
+};
 
 export default function CollaboratorsList({
   collaborators = [],
-  projectId,
 }: CollaboratorsListProps) {
   const { collaborators: realtimeCollaborators } = useSocket();
 
-  // Use real-time collaborators if available, otherwise fall back to prop collaborators
-  const activeCollaborators = realtimeCollaborators.length > 0 ? realtimeCollaborators : collaborators;
+  const activeCollaborators: AnyCollaborator[] =
+    realtimeCollaborators.length > 0 ? realtimeCollaborators : collaborators;
   const onlineCount = activeCollaborators.length;
 
   return (
     <div className="flex items-center gap-2">
       <div className="flex -space-x-2">
         {activeCollaborators.slice(0, 3).map((collaborator) => (
-          <div key={collaborator.userId || (collaborator as any).user_id} className="relative">
+          <div key={getCollaboratorId(collaborator)} className="relative">
             <img
-              src={(collaborator.userAvatar || (collaborator as any).user_avatar) || "/placeholder.svg"}
-              alt={(collaborator.userName || (collaborator as any).full_name) || "Collaborator"}
+              src={getCollaboratorAvatar(collaborator)}
+              alt={getCollaboratorName(collaborator)}
               className="w-8 h-8 rounded-full border-2 border-background"
             />
-            <div
-              className={`absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-background bg-green-500`}
-            />
+            <div className="absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-background bg-green-500" />
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- load project collaborators from Supabase so the header shows real members
- map Supabase rows into the shared Collaborator type and log failures gracefully
- update the collaborators list component to handle both Supabase rows and socket payloads without type assertions

## Testing
- npm run lint *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68dfac442e588332a047f2394f596c3c