### PR TITLE
feat: respect DOCKER_HOST across platforms

### DIFF
--- a/code-execution-backend/README.md
+++ b/code-execution-backend/README.md
@@ -187,12 +187,20 @@ RATE_LIMIT_MAX_REQUESTS=100
 CONTAINER_TIMEOUT_MS=30000
 CONTAINER_MEMORY_LIMIT=128m
 CONTAINER_CPU_LIMIT=0.5
+# Optional overrides (all platforms respect DOCKER_HOST; Windows can also set DOCKER_SOCKET)
+# DOCKER_HOST=tcp://127.0.0.1:2375
+# DOCKER_SOCKET=//./pipe/docker_engine
 
 # Execution Limits
 MAX_EXECUTION_TIME_MS=10000
 MAX_OUTPUT_SIZE_BYTES=10485760
 MAX_CODE_SIZE_BYTES=1048576
 ```
+
+The backend now respects the standard `DOCKER_HOST` environment variable across platforms. Provide a `unix://` socket path or a
+`tcp://` endpoint to point the service at a remote or custom Docker daemon. When an override is present, the service will still
+fall back to the default local socket (`/var/run/docker.sock` on Linux/macOS or the Windows named pipe) if the connection test
+fails, and Windows environments can continue to customize the pipe via `DOCKER_SOCKET`.
 
 ### Language Configuration
 

--- a/code-execution-backend/tests/dockerService.test.js
+++ b/code-execution-backend/tests/dockerService.test.js
@@ -1,0 +1,75 @@
+jest.mock('dockerode', () => {
+  return jest.fn().mockImplementation(() => ({
+    ping: jest.fn().mockResolvedValue()
+  }));
+});
+
+const DockerService = require('../src/services/dockerService');
+
+const originalPlatform = process.platform;
+const originalDockerHost = process.env.DOCKER_HOST;
+const originalDockerSocket = process.env.DOCKER_SOCKET;
+
+const setPlatform = (platform) => {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true
+  });
+};
+
+describe('DockerService buildDockerOptions', () => {
+  afterEach(() => {
+    if (originalDockerHost === undefined) {
+      delete process.env.DOCKER_HOST;
+    } else {
+      process.env.DOCKER_HOST = originalDockerHost;
+    }
+
+    if (originalDockerSocket === undefined) {
+      delete process.env.DOCKER_SOCKET;
+    } else {
+      process.env.DOCKER_SOCKET = originalDockerSocket;
+    }
+
+    setPlatform(originalPlatform);
+    jest.clearAllMocks();
+  });
+
+  it('parses unix socket DOCKER_HOST on linux', () => {
+    setPlatform('linux');
+    process.env.DOCKER_HOST = 'unix:///tmp/docker.sock';
+
+    const service = new DockerService();
+    const { dockerOptions, fallbackDockerOptions } = service;
+
+    expect(dockerOptions).toEqual({ socketPath: '/tmp/docker.sock' });
+    expect(fallbackDockerOptions).toEqual({ socketPath: '/var/run/docker.sock' });
+  });
+
+  it('parses tcp DOCKER_HOST on darwin', () => {
+    setPlatform('darwin');
+    process.env.DOCKER_HOST = 'tcp://127.0.0.1:2375';
+
+    const service = new DockerService();
+    const { dockerOptions, fallbackDockerOptions } = service;
+
+    expect(dockerOptions).toEqual({
+      host: '127.0.0.1',
+      port: 2375,
+      protocol: 'http'
+    });
+    expect(fallbackDockerOptions).toEqual({ socketPath: '/var/run/docker.sock' });
+  });
+
+  it('parses npipe DOCKER_HOST on windows', () => {
+    setPlatform('win32');
+    process.env.DOCKER_SOCKET = '//./pipe/docker_engine';
+    process.env.DOCKER_HOST = 'npipe:////./pipe/custom_engine';
+
+    const service = new DockerService();
+    const { dockerOptions, fallbackDockerOptions } = service;
+
+    expect(dockerOptions).toEqual({ socketPath: '//./pipe/custom_engine' });
+    expect(fallbackDockerOptions).toEqual({ socketPath: '//./pipe/docker_engine' });
+  });
+});


### PR DESCRIPTION
## Summary
- update the Docker service to derive connection options from DOCKER_HOST for unix, tcp, and npipe URIs while keeping socket fallbacks
- document the new configuration behavior in the backend README
- add Jest coverage for Linux, macOS, and Windows style overrides

## Testing
- node ./node_modules/jest/bin/jest.js

------
https://chatgpt.com/codex/tasks/task_e_68dff472e03c83329ff8d8d0afbdb64d