### PR TITLE
fix: preserve docker connection error metadata

### DIFF
--- a/code-execution-backend/src/services/dockerService.js
+++ b/code-execution-backend/src/services/dockerService.js
@@ -191,11 +191,13 @@ class DockerService {
             ? fallbackError.message
             : 'Unknown error';
           logger.error('Docker fallback connection failed', { error: fallbackMessage });
-          throw new Error(`Docker connection failed: ${fallbackMessage}`);
+          fallbackError.message = `Docker connection failed: ${fallbackMessage}`;
+          throw fallbackError;
         }
       }
 
-      throw new Error(`Docker connection failed: ${message}`);
+      error.message = `Docker connection failed: ${message}`;
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary
- keep Docker connection errors intact by rethrowing the original error object in both primary and fallback paths
- update the Docker service test to exercise the real connection logic and assert permission guidance is returned

## Testing
- npm test -- dockerService

------
https://chatgpt.com/codex/tasks/task_e_68e0021bfb448332b0c3fe40b336eef2