### PR TITLE
docs: clarify docker requirements for language tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ cd code-execution-backend && npm run dev  # Port 3001
 npm run dev  # Port 3000
 ```
 
+### 🐳 Docker prerequisites for the execution service
+
+- The majority of languages (Java, TypeScript, SQL, C#, Go, Rust) now run inside the consolidated `code-exec-multi` image. Build or refresh it locally with `cd code-execution-backend && npm run docker:build` before running tests that touch those languages.
+- Ensure Docker Desktop (Windows/macOS) or the Docker daemon (`dockerd`) on Linux is running. When Docker is offline the backend logs show `Docker connection failed: Unknown error`, and language tests exit with "Docker is not running or not accessible".
+- If you prefer to use language-specific base images again, adjust `code-execution-backend/src/config/languages.js` and rebuild the relevant images. The backend will pick up the change on the next execution.
+
 **API Usage Example**:
 ```javascript
 // Execute Python code

--- a/docs/code-execution-system-debug.md
+++ b/docs/code-execution-system-debug.md
@@ -3,6 +3,10 @@
 ## Overview
 This document explains how the CodeJoin code execution system works and the current issues with C/C++ execution in the terminal.
 
+> **Quick fix for "Docker connection failed" errors**
+>
+> If the backend logs show `Docker connection test failed {"error":"Unknown error"}` followed by `Docker connection failed: Unknown error`, the Docker daemon is offline or unreachable from the backend. Start Docker Desktop (or `dockerd` on Linux) and re-run `npm run dev` for the `code-execution-backend`. When Docker is healthy, `docker info` should succeed and the backend will build or pull the required images automatically.
+
 ## System Architecture
 
 ### 1. Execution Flow Components


### PR DESCRIPTION
## Summary
- document the quick fix for Docker connection failures in the execution backend
- add README notes explaining why the consolidated code-exec-multi image is used and how to rebuild it

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e00b8504848332b15bf4b588d33989