### PR TITLE
feat: connect project sharing modal to supabase

### DIFF
--- a/components/project-sharing-modal.tsx
+++ b/components/project-sharing-modal.tsx
@@ -1,54 +1,54 @@
-'use client'
+"use client";
 
-import { useState } from 'react'
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogTrigger
-} from "@/components/ui/dialog"
+} from "@/components/ui/dialog";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue
-} from "@/components/ui/select"
-import { Badge } from "@/components/ui/badge"
-import { Separator } from "@/components/ui/separator"
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
 import {
   Share2,
   Copy,
-  Mail,
   Eye,
   Edit3,
   Trash2,
-  Link,
   UserPlus,
-  Globe,
-  Lock
-} from "lucide-react"
-import { toast } from "sonner"
+  Lock,
+  Loader2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { getSupabaseClient } from "@/lib/supabaseClient";
 
 interface ProjectSharingModalProps {
-  projectId: string
-  projectName: string
-  isOpen: boolean
-  onOpenChange: (open: boolean) => void
+  projectId: string;
+  projectName: string;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
+type SharedUserRole = "viewer" | "editor" | "admin";
+
 interface SharedUser {
-  id: string
-  email: string
-  name?: string
-  avatar?: string
-  role: 'viewer' | 'editor' | 'admin'
-  addedAt: Date
+  id: string;
+  email: string;
+  name?: string | null;
+  avatar?: string | null;
+  role: SharedUserRole;
+  addedAt?: Date;
 }
 
 export default function ProjectSharingModal({
@@ -57,101 +57,324 @@ export default function ProjectSharingModal({
   isOpen,
   onOpenChange,
 }: ProjectSharingModalProps) {
-  const [shareLink, setShareLink] = useState(`${window.location.origin}/project/${projectId}`)
-  const [linkAccess, setLinkAccess] = useState<'private' | 'view' | 'edit'>('private')
-  const [emailToAdd, setEmailToAdd] = useState('')
-  const [roleToAdd, setRoleToAdd] = useState<'viewer' | 'editor'>('viewer')
-  const [sharedUsers, setSharedUsers] = useState<SharedUser[]>([
-    {
-      id: '1',
-      email: 'john@example.com',
-      name: 'John Doe',
-      avatar: '/placeholder.svg',
-      role: 'editor',
-      addedAt: new Date(2024, 0, 15)
-    },
-    {
-      id: '2',
-      email: 'sarah@example.com',
-      name: 'Sarah Wilson',
-      role: 'viewer',
-      addedAt: new Date(2024, 0, 20)
-    }
-  ])
+  const supabase = getSupabaseClient();
+  const [shareLink, setShareLink] = useState<string>("");
+  const [linkAccess, setLinkAccess] = useState<"private" | "view" | "edit">(
+    "private"
+  );
+  const [emailToAdd, setEmailToAdd] = useState("");
+  const [roleToAdd, setRoleToAdd] = useState<"viewer" | "editor">("viewer");
+  const [sharedUsers, setSharedUsers] = useState<SharedUser[]>([]);
+  const [isLoadingUsers, setIsLoadingUsers] = useState(false);
+  const [isAddingUser, setIsAddingUser] = useState(false);
+  const [updatingUserId, setUpdatingUserId] = useState<string | null>(null);
+  const [removingUserId, setRemovingUserId] = useState<string | null>(null);
+  const [isSupabaseUnavailable, setIsSupabaseUnavailable] = useState(false);
 
-  const copyShareLink = async () => {
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    setShareLink(`${window.location.origin}/project/${projectId}`);
+  }, [projectId]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    if (!supabase) {
+      setIsSupabaseUnavailable(true);
+      return;
+    }
+
+    setIsSupabaseUnavailable(false);
+    let isActive = true;
+    const fetchCollaborators = async () => {
+      setIsLoadingUsers(true);
+
+      const { data, error } = await supabase
+        .from("collaborators")
+        .select(
+          "user_id, role, created_at, profiles ( email, full_name, user_avatar )"
+        )
+        .eq("project_id", projectId);
+
+      if (!isActive) {
+        return;
+      }
+
+      if (error) {
+        console.error("Failed to load collaborators", error);
+        toast.error("Unable to load collaborators right now.");
+        setIsLoadingUsers(false);
+        return;
+      }
+
+      type CollaboratorRow = {
+        user_id: string;
+        role: string | null;
+        created_at: string | null;
+        profiles: {
+          email: string | null;
+          full_name: string | null;
+          user_avatar: string | null;
+        } | null;
+      };
+
+      const mappedUsers = (data as CollaboratorRow[]).map((row) => {
+        const resolveRole = (value: string | null): SharedUserRole => {
+          if (value === "editor" || value === "admin") {
+            return value;
+          }
+          return "viewer";
+        };
+
+        const profile = row.profiles;
+
+        return {
+          id: row.user_id,
+          email: profile?.email ?? "",
+          name: profile?.full_name,
+          avatar: profile?.user_avatar,
+          role: resolveRole(row.role),
+          addedAt: row.created_at ? new Date(row.created_at) : undefined,
+        } satisfies SharedUser;
+      });
+
+      setSharedUsers(mappedUsers);
+      setIsLoadingUsers(false);
+    };
+
+    fetchCollaborators();
+
+    return () => {
+      isActive = false;
+    };
+  }, [isOpen, projectId, supabase]);
+
+  const addUserByEmail = useCallback(async () => {
+    if (!emailToAdd) {
+      return;
+    }
+
+    if (!supabase) {
+      toast.error("Supabase is not configured. Unable to invite collaborators.");
+      return;
+    }
+
+    setIsAddingUser(true);
+
     try {
-      await navigator.clipboard.writeText(shareLink)
-      toast.success('Share link copied to clipboard!')
+      const { data: profile, error: profileError } = await supabase
+        .from("profiles")
+        .select("id, email, full_name, user_avatar")
+        .eq("email", emailToAdd)
+        .maybeSingle();
+
+      if (profileError) {
+        console.error("Failed to look up profile", profileError);
+        toast.error("Unable to find that user right now.");
+        return;
+      }
+
+      if (!profile) {
+        toast.error("No user with that email exists.");
+        return;
+      }
+
+      const { data: existing, error: existingError } = await supabase
+        .from("collaborators")
+        .select("user_id")
+        .eq("project_id", projectId)
+        .eq("user_id", profile.id)
+        .maybeSingle();
+
+      if (existingError) {
+        console.error("Failed to verify collaborator", existingError);
+      }
+
+      if (existing) {
+        toast.info("That user already has access to this project.");
+        return;
+      }
+
+      const { data: inserted, error: insertError } = await supabase
+        .from("collaborators")
+        .insert({
+          project_id: projectId,
+          user_id: profile.id,
+          role: roleToAdd,
+        })
+        .select(
+          "user_id, role, created_at, profiles ( email, full_name, user_avatar )"
+        )
+        .single();
+
+      if (insertError) {
+        console.error("Failed to invite collaborator", insertError);
+        toast.error("Could not add that collaborator. Please try again.");
+        return;
+      }
+
+      const newUser: SharedUser = {
+        id: inserted.user_id,
+        email: inserted.profiles?.email ?? profile.email ?? "",
+        name: inserted.profiles?.full_name ?? profile.full_name ?? null,
+        avatar: inserted.profiles?.user_avatar ?? profile.user_avatar ?? null,
+        role: roleToAdd,
+        addedAt: inserted.created_at ? new Date(inserted.created_at) : new Date(),
+      };
+
+      setSharedUsers((prev) => [...prev, newUser]);
+      setEmailToAdd("");
+      setRoleToAdd("viewer");
+      toast.success(`Invitation sent to ${newUser.email}.`);
+    } finally {
+      setIsAddingUser(false);
+    }
+  }, [emailToAdd, projectId, roleToAdd, supabase]);
+
+  const removeUser = useCallback(
+    async (userId: string) => {
+      if (!supabase) {
+        toast.error("Supabase is not configured. Unable to remove collaborators.");
+        return;
+      }
+
+      setRemovingUserId(userId);
+
+      try {
+        const { error } = await supabase
+          .from("collaborators")
+          .delete()
+          .eq("project_id", projectId)
+          .eq("user_id", userId);
+
+        if (error) {
+          console.error("Failed to remove collaborator", error);
+          toast.error("Could not remove that collaborator. Please try again.");
+          return;
+        }
+
+        setSharedUsers((prev) => prev.filter((user) => user.id !== userId));
+        toast.success("User removed from project");
+      } finally {
+        setRemovingUserId(null);
+      }
+    },
+    [projectId, supabase]
+  );
+
+  const updateUserRole = useCallback(
+    async (userId: string, newRole: SharedUserRole) => {
+      if (!supabase) {
+        toast.error("Supabase is not configured. Unable to update roles.");
+        return;
+      }
+
+      setUpdatingUserId(userId);
+
+      try {
+        const { error } = await supabase
+          .from("collaborators")
+          .update({ role: newRole })
+          .eq("project_id", projectId)
+          .eq("user_id", userId);
+
+        if (error) {
+          console.error("Failed to update collaborator role", error);
+          toast.error("Could not update that role. Please try again.");
+          return;
+        }
+
+        setSharedUsers((prev) =>
+          prev.map((user) =>
+            user.id === userId
+              ? {
+                  ...user,
+                  role: newRole,
+                }
+              : user
+          )
+        );
+        toast.success("User role updated");
+      } finally {
+        setUpdatingUserId(null);
+      }
+    },
+    [projectId, supabase]
+  );
+
+  const copyShareLink = useCallback(async () => {
+    if (!shareLink) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareLink);
+      toast.success("Share link copied to clipboard!");
     } catch (error) {
-      toast.error('Failed to copy link')
+      toast.error("Failed to copy link");
     }
-  }
+  }, [shareLink]);
 
-  const addUserByEmail = async () => {
-    if (!emailToAdd) return
+  const updateLinkAccess = useCallback(
+    (access: "private" | "view" | "edit") => {
+      setLinkAccess(access);
 
-    // Simulate API call
-    const newUser: SharedUser = {
-      id: Date.now().toString(),
-      email: emailToAdd,
-      role: roleToAdd,
-      addedAt: new Date()
-    }
+      if (typeof window === "undefined") {
+        return;
+      }
 
-    setSharedUsers(prev => [...prev, newUser])
-    setEmailToAdd('')
-    setRoleToAdd('viewer')
-    toast.success(`Invitation sent to ${emailToAdd}`)
-  }
+      const baseUrl = `${window.location.origin}/project/${projectId}`;
+      switch (access) {
+        case "view":
+          setShareLink(`${baseUrl}?access=view`);
+          break;
+        case "edit":
+          setShareLink(`${baseUrl}?access=edit`);
+          break;
+        default:
+          setShareLink(baseUrl);
+      }
+    },
+    [projectId]
+  );
 
-  const removeUser = (userId: string) => {
-    setSharedUsers(prev => prev.filter(user => user.id !== userId))
-    toast.success('User removed from project')
-  }
+  const roleOptions = useMemo(
+    () => [
+      { value: "viewer" satisfies SharedUserRole, label: "Viewer" },
+      { value: "editor" satisfies SharedUserRole, label: "Editor" },
+      { value: "admin" satisfies SharedUserRole, label: "Admin" },
+    ],
+    []
+  );
 
-  const updateUserRole = (userId: string, newRole: SharedUser['role']) => {
-    setSharedUsers(prev =>
-      prev.map(user =>
-        user.id === userId ? { ...user, role: newRole } : user
-      )
-    )
-    toast.success('User role updated')
-  }
-
-  const updateLinkAccess = (access: 'private' | 'view' | 'edit') => {
-    setLinkAccess(access)
-    // Generate different link based on access level
-    const baseUrl = `${window.location.origin}/project/${projectId}`
-    switch (access) {
-      case 'view':
-        setShareLink(`${baseUrl}?access=view`)
-        break
-      case 'edit':
-        setShareLink(`${baseUrl}?access=edit`)
-        break
+  const getRoleColor = (role: SharedUserRole) => {
+    switch (role) {
+      case "admin":
+        return "bg-red-100 text-red-800";
+      case "editor":
+        return "bg-blue-100 text-blue-800";
+      case "viewer":
       default:
-        setShareLink(baseUrl)
+        return "bg-gray-100 text-gray-800";
     }
-  }
+  };
 
-  const getRoleColor = (role: SharedUser['role']) => {
+  const getRoleIcon = (role: SharedUserRole) => {
     switch (role) {
-      case 'admin': return 'bg-red-100 text-red-800'
-      case 'editor': return 'bg-blue-100 text-blue-800'
-      case 'viewer': return 'bg-gray-100 text-gray-800'
-      default: return 'bg-gray-100 text-gray-800'
+      case "admin":
+        return <Lock className="h-3 w-3" />;
+      case "editor":
+        return <Edit3 className="h-3 w-3" />;
+      case "viewer":
+      default:
+        return <Eye className="h-3 w-3" />;
     }
-  }
-
-  const getRoleIcon = (role: SharedUser['role']) => {
-    switch (role) {
-      case 'admin': return <Lock className="h-3 w-3" />
-      case 'editor': return <Edit3 className="h-3 w-3" />
-      case 'viewer': return <Eye className="h-3 w-3" />
-      default: return <Eye className="h-3 w-3" />
-    }
-  }
+  };
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -206,11 +429,11 @@ export default function ProjectSharingModal({
               </Button>
             </div>
 
-            {linkAccess !== 'private' && (
+            {linkAccess !== "private" && (
               <p className="text-sm text-muted-foreground">
-                {linkAccess === 'view'
-                  ? 'Anyone with this link can view the project'
-                  : 'Anyone with this link can view and edit the project'
+                {linkAccess === "view"
+                  ? "Anyone with this link can view the project"
+                  : "Anyone with this link can view and edit the project"
                 }
               </p>
             )}
@@ -228,9 +451,14 @@ export default function ProjectSharingModal({
                 value={emailToAdd}
                 onChange={(e) => setEmailToAdd(e.target.value)}
                 className="flex-1"
+                disabled={isSupabaseUnavailable || isAddingUser}
               />
               <div className="flex gap-2">
-                <Select value={roleToAdd} onValueChange={(value: 'viewer' | 'editor') => setRoleToAdd(value)}>
+                <Select
+                  value={roleToAdd}
+                  onValueChange={(value: "viewer" | "editor") => setRoleToAdd(value)}
+                  disabled={isSupabaseUnavailable || isAddingUser}
+                >
                   <SelectTrigger className="w-full sm:w-32">
                     <SelectValue />
                   </SelectTrigger>
@@ -239,11 +467,25 @@ export default function ProjectSharingModal({
                     <SelectItem value="editor">Editor</SelectItem>
                   </SelectContent>
                 </Select>
-                <Button onClick={addUserByEmail} disabled={!emailToAdd} className="shrink-0">
-                  <UserPlus className="h-4 w-4" />
+                <Button
+                  onClick={addUserByEmail}
+                  disabled={!emailToAdd || isSupabaseUnavailable || isAddingUser}
+                  className="shrink-0"
+                >
+                  {isAddingUser ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <UserPlus className="h-4 w-4" />
+                  )}
                 </Button>
               </div>
             </div>
+
+            {isSupabaseUnavailable && (
+              <p className="text-sm text-muted-foreground">
+                Configure Supabase environment variables to invite collaborators.
+              </p>
+            )}
           </div>
 
           <Separator />
@@ -255,62 +497,86 @@ export default function ProjectSharingModal({
             </Label>
 
             <div className="space-y-2 max-h-48 sm:max-h-60 overflow-y-auto">
-              {sharedUsers.map((user) => (
-                <div key={user.id} className="flex items-center justify-between p-2 rounded-lg border">
-                  <div className="flex items-center gap-3">
-                    {user.avatar && (
-                      <img
-                        src={user.avatar}
-                        alt={user.name || user.email}
-                        className="w-8 h-8 rounded-full"
-                      />
-                    )}
-                    <div className="flex flex-col">
-                      <span className="font-medium text-sm">
-                        {user.name || user.email}
-                      </span>
-                      {user.name && (
-                        <span className="text-xs text-muted-foreground">
-                          {user.email}
-                        </span>
+              {isLoadingUsers ? (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Loading collaborators...
+                </div>
+              ) : sharedUsers.length > 0 ? (
+                sharedUsers.map((user) => (
+                  <div
+                    key={user.id}
+                    className="flex items-center justify-between p-2 rounded-lg border"
+                  >
+                    <div className="flex items-center gap-3">
+                      {user.avatar && (
+                        <img
+                          src={user.avatar}
+                          alt={user.name || user.email}
+                          className="w-8 h-8 rounded-full"
+                        />
                       )}
+                      <div className="flex flex-col">
+                        <span className="font-medium text-sm">
+                          {user.name || user.email || "Unknown collaborator"}
+                        </span>
+                        {(user.name || user.email) && (
+                          <span className="text-xs text-muted-foreground">
+                            {user.email}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <Badge
+                        variant="secondary"
+                        className={`${getRoleColor(user.role)} flex items-center gap-1`}
+                      >
+                        {getRoleIcon(user.role)}
+                        {user.role.charAt(0).toUpperCase() + user.role.slice(1)}
+                      </Badge>
+
+                      <Select
+                        value={user.role}
+                        onValueChange={(value: SharedUserRole) =>
+                          updateUserRole(user.id, value)
+                        }
+                        disabled={updatingUserId === user.id || isSupabaseUnavailable}
+                      >
+                        <SelectTrigger className="w-20 h-8 text-xs">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {roleOptions.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => removeUser(user.id)}
+                        className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                        disabled={removingUserId === user.id || isSupabaseUnavailable}
+                      >
+                        {removingUserId === user.id ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-4 w-4" />
+                        )}
+                      </Button>
                     </div>
                   </div>
-
-                  <div className="flex items-center gap-2">
-                    <Badge
-                      variant="secondary"
-                      className={`${getRoleColor(user.role)} flex items-center gap-1`}
-                    >
-                      {getRoleIcon(user.role)}
-                      {user.role.charAt(0).toUpperCase() + user.role.slice(1)}
-                    </Badge>
-
-                    <Select
-                      value={user.role}
-                      onValueChange={(value: SharedUser['role']) => updateUserRole(user.id, value)}
-                    >
-                      <SelectTrigger className="w-20 h-8 text-xs">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="viewer">Viewer</SelectItem>
-                        <SelectItem value="editor">Editor</SelectItem>
-                        <SelectItem value="admin">Admin</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => removeUser(user.id)}
-                      className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                </div>
-              ))}
+                ))
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No collaborators have been added yet.
+                </p>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- load project collaborators directly from Supabase when opening the share modal
- allow inviting teammates by email, updating roles, and removing collaborators through Supabase mutations
- add graceful loading, error, and unavailable states when Supabase configuration is missing

## Testing
- npm run lint *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b86482e88332badc37b4edbbfde4