### PR TITLE
feat: connect workspace chat to supabase

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -1,63 +1,385 @@
-"use client"
+"use client";
 
-import { useState } from "react"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Send, Mic, MicOff, Brain } from "lucide-react"
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Send, Mic, MicOff, Brain } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { getSupabaseClient } from "@/lib/supabaseClient";
+import type { Collaborator, ProjectChatMessageWithAuthor } from "@/lib/types";
+import { useToast } from "@/hooks/use-toast";
 
-interface ChatPanelProps {
-  collaborators: Array<{
-    id: number
-    name: string
-    avatar: string
-  }>
+interface LiveCollaborator {
+  userId: string;
+  userName: string;
+  userAvatar?: string;
+  socketId: string;
+  lastActivity: Date;
 }
 
-export default function ChatPanel({ collaborators }: ChatPanelProps) {
-  const [message, setMessage] = useState("")
-  const [isAskingAI, setIsAskingAI] = useState(false)
-  const [isRecording, setIsRecording] = useState(false)
-  const [messages, setMessages] = useState<Array<{
-    id: number;
-    user: string;
-    message: string;
-    time: string;
-    avatar: string;
-    isAI: boolean;
-  }>>([])
-  // Chat starts empty - messages will be added as users communicate
+interface Identity {
+  userId: string;
+  userName: string;
+  userAvatar?: string;
+}
 
-  const handleSendMessage = () => {
-    if (message.trim()) {
-      const newMessage = {
-        id: messages.length + 1,
-        user: isAskingAI ? "You → AI" : "You",
-        message: message,
-        time: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
-        avatar: "/placeholder.svg?height=32&width=32",
-        isAI: false,
-      }
-      setMessages([...messages, newMessage])
-      setMessage("")
+interface ChatPanelProps {
+  conversationId: string | null;
+  initialMessages: ProjectChatMessageWithAuthor[];
+  teamMembers: Collaborator[];
+  collaborators: LiveCollaborator[];
+  selfIdentity: Identity | null;
+}
 
-      // If asking AI, simulate AI response
-      if (isAskingAI) {
-        setTimeout(() => {
-          const aiResponse = {
-            id: messages.length + 2,
-            user: "AI Assistant",
-            message: "I'm analyzing your request. Let me help you with that...",
-            time: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
-            avatar: "/placeholder.svg?height=32&width=32",
-            isAI: true,
-          }
-          setMessages((prev) => [...prev, aiResponse])
-          setIsAskingAI(false)
-        }, 1000)
+type DisplayMessage = {
+  id: string;
+  content: string;
+  createdAt: string;
+  userId: string | null;
+  authorName: string;
+  authorAvatar: string | null;
+  metadata: Record<string, unknown> | null;
+  isAI: boolean;
+  isPending: boolean;
+};
+
+type MessageRecord = {
+  id: string;
+  content: string | null;
+  user_id: string | null;
+  created_at: string;
+  metadata: Record<string, unknown> | null;
+  user_full_name?: string | null;
+  user_avatar?: string | null;
+};
+
+const pickString = (value: unknown) =>
+  typeof value === "string" && value.trim().length > 0 ? value : null;
+
+const metadataString = (
+  metadata: Record<string, unknown> | null | undefined,
+  key: string
+) => {
+  const value = metadata?.[key];
+  return pickString(value);
+};
+
+const metadataBoolean = (
+  metadata: Record<string, unknown> | null | undefined,
+  key: string
+) => {
+  const value = metadata?.[key];
+  return typeof value === "boolean" ? value : false;
+};
+
+export default function ChatPanel({
+  conversationId,
+  initialMessages,
+  teamMembers,
+  collaborators,
+  selfIdentity,
+}: ChatPanelProps) {
+  const supabase = getSupabaseClient();
+  const { toast } = useToast();
+  const [message, setMessage] = useState("");
+  const [isAskingAI, setIsAskingAI] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const [messages, setMessages] = useState<DisplayMessage[]>([]);
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+
+  const teamMemberMap = useMemo(() => {
+    const map = new Map<string, Collaborator>();
+    for (const member of teamMembers ?? []) {
+      if (member.user_id) {
+        map.set(member.user_id, member);
       }
     }
-  }
+    return map;
+  }, [teamMembers]);
+
+  const liveCollaboratorMap = useMemo(() => {
+    const map = new Map<string, LiveCollaborator>();
+    for (const collaborator of collaborators ?? []) {
+      if (collaborator.userId) {
+        map.set(collaborator.userId, collaborator);
+      }
+    }
+    return map;
+  }, [collaborators]);
+
+  const resolveAuthor = useCallback(
+    (
+      userId: string | null,
+      fallbackName: string,
+      fallbackAvatar: string | null,
+      metadata: Record<string, unknown> | null | undefined
+    ) => {
+      if (!userId) {
+        return {
+          name:
+            metadataString(metadata, "author_name") ??
+            fallbackName ??
+            "System",
+          avatar: metadataString(metadata, "avatar") ?? fallbackAvatar,
+        };
+      }
+
+      if (selfIdentity && selfIdentity.userId === userId) {
+        return {
+          name: selfIdentity.userName,
+          avatar: selfIdentity.userAvatar ?? fallbackAvatar,
+        };
+      }
+
+      const teammate = teamMemberMap.get(userId);
+      if (teammate) {
+        return {
+          name: teammate.full_name ?? fallbackName ?? "Teammate",
+          avatar: teammate.user_avatar ?? fallbackAvatar,
+        };
+      }
+
+      const live = liveCollaboratorMap.get(userId);
+      if (live) {
+        return {
+          name: live.userName,
+          avatar: live.userAvatar ?? fallbackAvatar,
+        };
+      }
+
+      return {
+        name: fallbackName || "Teammate",
+        avatar: fallbackAvatar,
+      };
+    },
+    [teamMemberMap, liveCollaboratorMap, selfIdentity]
+  );
+
+  const formatMessage = useCallback(
+    (record: ProjectChatMessageWithAuthor | MessageRecord): DisplayMessage => {
+      const fallbackName =
+        pickString(record.user_full_name) ??
+        metadataString(record.metadata, "author_name") ??
+        "Teammate";
+      const fallbackAvatar =
+        pickString(record.user_avatar) ??
+        metadataString(record.metadata, "avatar");
+
+      const author = resolveAuthor(
+        record.user_id ?? null,
+        fallbackName,
+        fallbackAvatar,
+        record.metadata
+      );
+
+      return {
+        id: record.id,
+        content: pickString(record.content) ?? record.content?.toString() ?? "",
+        createdAt: record.created_at ?? new Date().toISOString(),
+        userId: record.user_id ?? null,
+        authorName: author.name,
+        authorAvatar: author.avatar ?? fallbackAvatar ?? null,
+        metadata: record.metadata ?? null,
+        isAI:
+          metadataBoolean(record.metadata, "is_ai") ||
+          author.name === "AI Assistant",
+        isPending: false,
+      };
+    },
+    [resolveAuthor]
+  );
+
+  useEffect(() => {
+    setMessages(initialMessages.map((record) => formatMessage(record)));
+  }, [initialMessages, formatMessage]);
+
+  useEffect(() => {
+    if (!supabase || !conversationId) {
+      return;
+    }
+
+    const channel = supabase
+      .channel(`project-chat-${conversationId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "messages",
+          filter: `conversation_id=eq.${conversationId}`,
+        },
+        (payload) => {
+          const record = payload.new as MessageRecord;
+          setMessages((prev) => {
+            const formatted = formatMessage(record);
+            const clientRef = metadataString(record.metadata, "client_ref");
+            const existingIndex = prev.findIndex(
+              (msg) =>
+                msg.id === formatted.id ||
+                (clientRef && msg.id === clientRef)
+            );
+
+            if (existingIndex !== -1) {
+              const next = [...prev];
+              next[existingIndex] = { ...formatted, isPending: false };
+              return next;
+            }
+
+            return [...prev, formatted];
+          });
+        }
+      )
+      .subscribe();
+
+    return () => {
+      channel
+        .unsubscribe()
+        .catch((error) =>
+          console.warn("Failed to unsubscribe chat channel", error)
+        );
+    };
+  }, [supabase, conversationId, formatMessage]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const handleSendMessage = useCallback(async () => {
+    const trimmed = message.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const timestamp = new Date().toISOString();
+
+    if (!supabase || !conversationId) {
+      const localId =
+        typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+          ? crypto.randomUUID()
+          : `local-${Date.now()}`;
+
+      const displayName = selfIdentity?.userName ?? "You";
+
+      const localMessage: DisplayMessage = {
+        id: localId,
+        content: trimmed,
+        createdAt: timestamp,
+        userId: selfIdentity?.userId ?? null,
+        authorName: isAskingAI ? `${displayName} → AI` : displayName,
+        authorAvatar: selfIdentity?.userAvatar ?? null,
+        metadata: null,
+        isAI: false,
+        isPending: false,
+      };
+
+      setMessages((prev) => [...prev, localMessage]);
+      setMessage("");
+
+      if (isAskingAI) {
+        setTimeout(() => {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: `${localId}-ai`,
+              content: "I'm analyzing your request. Let me help you with that...",
+              createdAt: new Date().toISOString(),
+              userId: null,
+              authorName: "AI Assistant",
+              authorAvatar: null,
+              metadata: { is_ai: true },
+              isAI: true,
+              isPending: false,
+            },
+          ]);
+          setIsAskingAI(false);
+        }, 1000);
+      }
+
+      return;
+    }
+
+    const clientRef =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `client-${Date.now()}`;
+
+    const optimisticMetadata: Record<string, unknown> = {
+      client_ref: clientRef,
+      is_ai: false,
+    };
+
+    if (selfIdentity?.userName) {
+      optimisticMetadata.author_name = selfIdentity.userName;
+    }
+    if (selfIdentity?.userAvatar) {
+      optimisticMetadata.avatar = selfIdentity.userAvatar;
+    }
+
+    const optimistic: DisplayMessage = {
+      id: clientRef,
+      content: trimmed,
+      createdAt: timestamp,
+      userId: selfIdentity?.userId ?? null,
+      authorName: selfIdentity?.userName ?? "You",
+      authorAvatar: selfIdentity?.userAvatar ?? null,
+      metadata: optimisticMetadata,
+      isAI: false,
+      isPending: true,
+    };
+
+    setMessages((prev) => [...prev, optimistic]);
+    setMessage("");
+    setIsSending(true);
+
+    const payload: Record<string, unknown> = {
+      conversation_id: conversationId,
+      content: trimmed,
+      metadata: {
+        ...optimisticMetadata,
+        ai_request: isAskingAI || undefined,
+      },
+    };
+
+    if (selfIdentity?.userId) {
+      payload.user_id = selfIdentity.userId;
+    }
+
+    const { error } = await supabase.from("messages").insert(payload);
+
+    if (error) {
+      console.warn("Failed to send chat message", error);
+      setMessages((prev) => prev.filter((msg) => msg.id !== clientRef));
+      toast({
+        variant: "destructive",
+        title: "Unable to send message",
+        description: error.message,
+      });
+      setIsSending(false);
+      return;
+    }
+
+    setIsSending(false);
+    setIsAskingAI(false);
+  }, [
+    supabase,
+    conversationId,
+    message,
+    selfIdentity,
+    isAskingAI,
+    toast,
+  ]);
 
   return (
     <div className="flex flex-col h-full">
@@ -72,24 +394,48 @@ export default function ChatPanel({ collaborators }: ChatPanelProps) {
           </div>
         ) : (
           messages.map((msg) => (
-            <div key={msg.id} className="flex gap-3">
+            <div
+              key={msg.id}
+              className={`flex gap-3 items-start ${
+                msg.isPending ? "opacity-70" : ""
+              }`}
+            >
               {msg.isAI ? (
                 <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
                   <Brain className="h-4 w-4 text-primary" />
                 </div>
               ) : (
-                <img src={msg.avatar || "/placeholder.svg"} alt={msg.user} className="w-8 h-8 rounded-full" />
+                <img
+                  src={msg.authorAvatar || "/placeholder.svg"}
+                  alt={msg.authorName}
+                  className="w-8 h-8 rounded-full object-cover"
+                />
               )}
-              <div className="flex-1">
+              <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 mb-1">
-                  <span className={`text-sm font-medium ${msg.isAI ? "text-primary" : ""}`}>{msg.user}</span>
-                  <span className="text-xs text-muted-foreground">{msg.time}</span>
+                  <span
+                    className={`text-sm font-medium ${
+                      msg.isAI ? "text-primary" : ""
+                    }`}
+                  >
+                    {msg.authorName}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(msg.createdAt).toLocaleTimeString([], {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                    {msg.isPending ? " • Sending…" : ""}
+                  </span>
                 </div>
-                <p className="text-sm">{msg.message}</p>
+                <p className="text-sm whitespace-pre-wrap break-words">
+                  {msg.content}
+                </p>
               </div>
             </div>
           ))
         )}
+        <div ref={messagesEndRef} />
       </div>
 
       <div className="p-4 border-t">
@@ -102,20 +448,31 @@ export default function ChatPanel({ collaborators }: ChatPanelProps) {
                   size="icon"
                   className="h-8 w-8"
                   onClick={() => setIsAskingAI(!isAskingAI)}
+                  disabled={isSending}
                 >
                   <Brain className="h-4 w-4" />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>{isAskingAI ? "Cancel AI query" : "Ask AI Assistant"}</TooltipContent>
+              <TooltipContent>
+                {isAskingAI ? "Cancel AI query" : "Ask AI Assistant"}
+              </TooltipContent>
             </Tooltip>
           </TooltipProvider>
 
           <Input
-            placeholder={isAskingAI ? "Ask AI a question..." : "Type a message..."}
+            placeholder={
+              isAskingAI ? "Ask AI a question..." : "Type a message..."
+            }
             value={message}
             onChange={(e) => setMessage(e.target.value)}
-            onKeyPress={(e) => e.key === "Enter" && handleSendMessage()}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                void handleSendMessage();
+              }
+            }}
             className={isAskingAI ? "border-primary" : ""}
+            disabled={isSending}
           />
 
           <TooltipProvider>
@@ -126,28 +483,42 @@ export default function ChatPanel({ collaborators }: ChatPanelProps) {
                   size="icon"
                   className="h-8 w-8"
                   onClick={() => setIsRecording(!isRecording)}
+                  disabled={isSending}
                 >
-                  {isRecording ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+                  {isRecording ? (
+                    <MicOff className="h-4 w-4" />
+                  ) : (
+                    <Mic className="h-4 w-4" />
+                  )}
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>{isRecording ? "Stop recording" : "Voice message"}</TooltipContent>
+              <TooltipContent>
+                {isRecording ? "Stop recording" : "Voice message"}
+              </TooltipContent>
             </Tooltip>
           </TooltipProvider>
 
-          <Button size="icon" className="h-8 w-8" onClick={handleSendMessage} disabled={!message.trim()}>
+          <Button
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => void handleSendMessage()}
+            disabled={!message.trim() || isSending}
+          >
             <Send className="h-4 w-4" />
           </Button>
         </div>
         {isAskingAI && (
-          <p className="text-xs text-primary mt-1">Asking AI Assistant - Your question will be shared with the team</p>
+          <p className="text-xs text-primary mt-1">
+            Asking AI Assistant - Your question will be shared with the team
+          </p>
         )}
         {isRecording && (
           <div className="flex items-center gap-2 mt-2 p-2 bg-destructive/10 rounded">
-            <div className="w-2 h-2 bg-destructive rounded-full animate-pulse"></div>
+            <div className="w-2 h-2 bg-destructive rounded-full animate-pulse" />
             <span className="text-xs">Recording... (0:05)</span>
           </div>
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -67,3 +67,13 @@ export interface ProjectNodeFromDB {
   content: string | null; // The code content for files
   language: string | null; // The programming language
 }
+
+export interface ProjectChatMessageWithAuthor {
+  id: string;
+  content: string;
+  created_at: string;
+  user_id: string | null;
+  user_full_name: string | null;
+  user_avatar: string | null;
+  metadata: Record<string, unknown> | null;
+}


### PR DESCRIPTION
## Summary
- ensure project pages create or reuse a Supabase conversation and load historical messages for the workspace
- extend the workspace chat panel to stream messages through Supabase realtime with optimistic updates and offline fallback
- add shared typing for resolved chat messages passed between the server page and client components

## Testing
- npm run lint *(fails: Failed to load config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68e0bf15f8608332a04c92aad8b64a71