### PR TITLE
fix: include role metadata in chat messages

### DIFF
--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -197,6 +197,7 @@ export default async function ProjectPage({
           content: string | null;
           created_at: string;
           metadata: Record<string, unknown> | null;
+          role?: string | null;
           user_id?: string | null;
         } & Record<string, unknown>;
 
@@ -244,6 +245,7 @@ export default async function ProjectPage({
             content: row.content ?? "",
             created_at: row.created_at,
             user_id: resolvedUserId ?? null,
+            role: row.role ?? null,
             user_full_name: profile?.full_name ?? null,
             user_avatar: profile?.user_avatar ?? null,
             metadata: row.metadata ?? null,

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -47,6 +47,7 @@ type DisplayMessage = {
   content: string;
   createdAt: string;
   userId: string | null;
+  role: string | null;
   authorName: string;
   authorAvatar: string | null;
   metadata: Record<string, unknown> | null;
@@ -59,6 +60,7 @@ type MessageRecord = {
   content: string | null;
   created_at: string;
   metadata: Record<string, unknown> | null;
+  role?: string | null;
   user_full_name?: string | null;
   user_avatar?: string | null;
   user_id?: string | null;
@@ -67,6 +69,7 @@ type MessageRecord = {
 type MessageLike = {
   user_id?: string | null;
   metadata?: Record<string, unknown> | null;
+  role?: string | null;
 };
 
 const pickString = (value: unknown) =>
@@ -216,6 +219,8 @@ export default function ChatPanel({
         metadataString(record.metadata, "avatar");
 
       const resolvedUserId = resolveRecordUserId(record);
+      const resolvedRole =
+        pickString(record.role) ?? metadataString(record.metadata, "role") ?? null;
 
       const author = resolveAuthor(
         resolvedUserId ?? null,
@@ -229,10 +234,12 @@ export default function ChatPanel({
         content: pickString(record.content) ?? record.content?.toString() ?? "",
         createdAt: record.created_at ?? new Date().toISOString(),
         userId: resolvedUserId ?? null,
+        role: resolvedRole,
         authorName: author.name,
         authorAvatar: author.avatar ?? fallbackAvatar ?? null,
         metadata: record.metadata ?? null,
         isAI:
+          resolvedRole === "assistant" ||
           metadataBoolean(record.metadata, "is_ai") ||
           author.name === "AI Assistant",
         isPending: false,
@@ -317,6 +324,7 @@ export default function ChatPanel({
         content: trimmed,
         createdAt: timestamp,
         userId: selfIdentity?.userId ?? null,
+        role: "user",
         authorName: isAskingAI ? `${displayName} → AI` : displayName,
         authorAvatar: selfIdentity?.userAvatar ?? null,
         metadata: null,
@@ -336,6 +344,7 @@ export default function ChatPanel({
               content: "I'm analyzing your request. Let me help you with that...",
               createdAt: new Date().toISOString(),
               userId: null,
+              role: "assistant",
               authorName: "AI Assistant",
               authorAvatar: null,
               metadata: { is_ai: true },
@@ -376,6 +385,7 @@ export default function ChatPanel({
       content: trimmed,
       createdAt: timestamp,
       userId: selfIdentity?.userId ?? null,
+      role: "user",
       authorName: selfIdentity?.userName ?? "You",
       authorAvatar: selfIdentity?.userAvatar ?? null,
       metadata: optimisticMetadata,
@@ -390,6 +400,7 @@ export default function ChatPanel({
     const payload: Record<string, unknown> = {
       conversation_id: conversationId,
       content: trimmed,
+      role: "user",
       metadata: {
         ...optimisticMetadata,
         ai_request: isAskingAI || undefined,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -73,6 +73,7 @@ export interface ProjectChatMessageWithAuthor {
   content: string;
   created_at: string;
   user_id: string | null;
+  role: string | null;
   user_full_name: string | null;
   user_avatar: string | null;
   metadata: Record<string, unknown> | null;


### PR DESCRIPTION
## Summary
- add the role attribute when sending chat messages so inserts satisfy the schema
- propagate role typing through Supabase message mapping and formatting so realtime updates remain consistent

## Testing
- npm run lint *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d0c177a48332a5e91690963c28bf