### PR TITLE
feat: enable project export downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "embla-carousel-react": "8.5.1",
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",
+    "jszip": "^3.10.1",
     "monaco-editor": "^0.53.0",
     "monaco-editor-webpack-plugin": "^7.1.0",
     "monaco-emmet": "^3.1.1",


### PR DESCRIPTION
## Summary
- replace the placeholder export routine with a real ZIP/JSON exporter powered by JSZip and detailed inline docs
- ensure selected files and folders keep their hierarchy, add optional metadata/history/settings manifests, and wire progress feedback into the modal
- add the jszip dependency to support archive generation

## Testing
- npm run lint *(fails: missing `next/core-web-vitals` ESLint config in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d13e9da08332b65f1f1635c40c58