### PR TITLE
fix: align chat payload author mapping

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -408,7 +408,7 @@ export default function ChatPanel({
     };
 
     if (selfIdentity?.userId) {
-      payload.user_id = selfIdentity.userId;
+      payload.author_id = selfIdentity.userId;
     }
 
     const { error } = await supabase.from("messages").insert(payload);


### PR DESCRIPTION
## Summary
- update the chat message payload to set `author_id` from the local identity so inserts use the correct column

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0ea51139c833289e3fa6d383eb51b