### PR TITLE
fix: preserve pending chat messages and clear sending state

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -248,9 +248,46 @@ export default function ChatPanel({
     [resolveAuthor]
   );
 
+  const formattedInitialMessages = useMemo(
+    () => initialMessages.map((record) => formatMessage(record)),
+    [initialMessages, formatMessage]
+  );
+
   useEffect(() => {
-    setMessages(initialMessages.map((record) => formatMessage(record)));
-  }, [initialMessages, formatMessage]);
+    setMessages((previous) => {
+      if (previous.length === 0) {
+        return formattedInitialMessages;
+      }
+
+      const initialMap = new Map(
+        formattedInitialMessages.map((message) => [message.id, message])
+      );
+
+      return previous.map((existing) => {
+        const refreshed = initialMap.get(existing.id);
+        if (refreshed) {
+          return {
+            ...refreshed,
+            isPending: existing.isPending && refreshed.isPending,
+          };
+        }
+
+        const resolvedAuthor = resolveAuthor(
+          existing.userId,
+          existing.authorName,
+          existing.authorAvatar,
+          existing.metadata
+        );
+
+        return {
+          ...existing,
+          authorName: resolvedAuthor.name,
+          authorAvatar:
+            resolvedAuthor.avatar ?? existing.authorAvatar ?? null,
+        };
+      });
+    });
+  }, [formattedInitialMessages, resolveAuthor]);
 
   useEffect(() => {
     if (!supabase || !conversationId) {
@@ -425,6 +462,16 @@ export default function ChatPanel({
       return;
     }
 
+    setMessages((prev) =>
+      prev.map((msg) =>
+        msg.id === clientRef
+          ? {
+              ...msg,
+              isPending: false,
+            }
+          : msg
+      )
+    );
     setIsSending(false);
     setIsAskingAI(false);
   }, [


### PR DESCRIPTION
## Summary
- avoid clobbering in-flight chat entries when collaborator metadata changes
- refresh author names and avatars for existing chat messages without dropping pending entries
- clear the optimistic "Sending…" state once the Supabase insert succeeds so the UI no longer sticks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1455056f48332aaff18270f71853e