### PR TITLE
fix: close docker stdin in finally

### DIFF
--- a/code-execution-backend/src/services/dockerService.js
+++ b/code-execution-backend/src/services/dockerService.js
@@ -92,14 +92,25 @@ class DockerService {
       // Test Docker connection first
       await this.testConnection();
 
+      const normalizedInput = this.normalizeInput(input);
+
       // Create container with security restrictions
-      container = await this.createSecureContainer(languageConfig, code, containerId, input);
+      container = await this.createSecureContainer(
+        languageConfig,
+        code,
+        containerId,
+        normalizedInput
+      );
 
       // Store reference for cleanup
       this.runningContainers.set(containerId, container);
 
       // Start container and capture output
-      const result = await this.runContainer(container, languageConfig);
+      const result = await this.runContainer(
+        container,
+        languageConfig,
+        normalizedInput
+      );
       const success = result.exitCode === 0;
 
       return {
@@ -410,11 +421,28 @@ class DockerService {
     await container.putArchive(pack, { path: '/tmp' });
   }
 
-  async runContainer(container, languageConfig) {
+  async runContainer(container, languageConfig, input = '') {
     const startTime = Date.now();
     let output = '';
     let error = '';
     let exitCode = 0;
+    let stdinStream = null;
+
+    if (typeof container.attach === 'function') {
+      try {
+        stdinStream = await container.attach({
+          stream: true,
+          stdin: true,
+          stdout: true,
+          stderr: true,
+          tty: false
+        });
+      } catch (attachError) {
+        logger.warn(
+          `Failed to attach to container stdin: ${attachError.message}`
+        );
+      }
+    }
 
     try {
       await container.start();
@@ -428,6 +456,11 @@ class DockerService {
 
       // Wait for container to complete or timeout
       const resultPromise = container.wait();
+
+      if (stdinStream) {
+        await this.writeInputToStream(stdinStream, input);
+      }
+
       const result = await Promise.race([resultPromise, timeoutPromise]);
 
       if (result.timedOut) {
@@ -459,6 +492,16 @@ class DockerService {
     } catch (e) {
       error = `Container execution error: ${e.message}`;
       exitCode = 1;
+    } finally {
+      if (stdinStream && typeof stdinStream.end === 'function') {
+        try {
+          stdinStream.end();
+        } catch (endError) {
+          logger.warn(
+            `Failed to close container stdin after run error: ${endError.message}`
+          );
+        }
+      }
     }
 
     const executionTime = Date.now() - startTime;
@@ -469,6 +512,38 @@ class DockerService {
       exitCode,
       executionTime
     };
+  }
+
+  async writeInputToStream(stream, input) {
+    const normalizedInput = this.normalizeInput(input);
+
+    if (!normalizedInput) {
+      return false;
+    }
+
+    return new Promise((resolve) => {
+      const handleFailure = (writeError) => {
+        if (writeError) {
+          logger.warn(
+            `Failed to write to container stdin: ${writeError.message}`
+          );
+        }
+        resolve(false);
+      };
+
+      try {
+        stream.write(normalizedInput, (writeError) => {
+          if (writeError) {
+            handleFailure(writeError);
+            return;
+          }
+
+          resolve(true);
+        });
+      } catch (writeError) {
+        handleFailure(writeError);
+      }
+    });
   }
 
   parseDockerStream(buffer) {

--- a/code-execution-backend/tests/runner.stdin.test.js
+++ b/code-execution-backend/tests/runner.stdin.test.js
@@ -1,0 +1,139 @@
+jest.mock('dockerode', () => jest.fn().mockImplementation(() => ({})));
+
+jest.mock('../src/utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn()
+}));
+
+const DockerService = require('../src/services/dockerService');
+const logger = require('../src/utils/logger');
+
+const createMockStream = (overrides = {}) => ({
+  write: jest.fn((value, callback) => {
+    if (typeof callback === 'function') {
+      callback();
+    }
+  }),
+  end: jest.fn(),
+  ...overrides
+});
+
+const createMockContainer = (streamOverrides) => {
+  const stream = createMockStream(streamOverrides);
+
+  return {
+    stream,
+    attach: jest.fn().mockResolvedValue(stream),
+    start: jest.fn().mockResolvedValue(),
+    wait: jest.fn().mockResolvedValue({ StatusCode: 0 }),
+    logs: jest.fn().mockResolvedValue(Buffer.alloc(0)),
+    kill: jest.fn()
+  };
+};
+
+describe('DockerService runContainer stdin handling', () => {
+  const languageConfig = { timeout: 25 };
+  let service;
+  let parseSpy;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    service = new DockerService();
+    parseSpy = jest
+      .spyOn(service, 'parseDockerStream')
+      .mockReturnValue({ stdout: 'program output', stderr: '' });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    parseSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  it('attaches to container stdin and writes normalized payload', async () => {
+    const container = createMockContainer();
+
+    const result = await service.runContainer(
+      container,
+      languageConfig,
+      'input without newline'
+    );
+
+    expect(container.attach).toHaveBeenCalledWith({
+      stream: true,
+      stdin: true,
+      stdout: true,
+      stderr: true,
+      tty: false
+    });
+    expect(container.stream.write).toHaveBeenCalledWith(
+      'input without newline\n',
+      expect.any(Function)
+    );
+    expect(container.stream.end).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(
+      expect.objectContaining({ output: 'program output', error: '', exitCode: 0 })
+    );
+  });
+
+  it('closes stdin without writing when input is empty', async () => {
+    const container = createMockContainer({
+      write: jest.fn(),
+      end: jest.fn()
+    });
+
+    await service.runContainer(container, languageConfig, '');
+
+    expect(container.stream.write).not.toHaveBeenCalled();
+    expect(container.stream.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes stdin even when write emits an error', async () => {
+    const writeError = new Error('boom');
+    const container = createMockContainer({
+      write: jest.fn((_value, callback) => {
+        if (typeof callback === 'function') {
+          callback(writeError);
+        }
+      }),
+      end: jest.fn()
+    });
+
+    await service.runContainer(container, languageConfig, 'data');
+
+    expect(container.stream.end).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to write to container stdin')
+    );
+  });
+
+  it('closes stdin in finally when writeInputToStream rejects', async () => {
+    const container = createMockContainer({
+      write: jest.fn(),
+      end: jest.fn()
+    });
+    const failure = new Error('write helper failure');
+    const writeSpy = jest
+      .spyOn(service, 'writeInputToStream')
+      .mockRejectedValue(failure);
+
+    const result = await service.runContainer(
+      container,
+      languageConfig,
+      'some data'
+    );
+
+    expect(container.stream.end).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(
+      expect.objectContaining({
+        exitCode: 1,
+        error: expect.stringContaining(failure.message)
+      })
+    );
+
+    writeSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- always close docker stdin streams from `runContainer`'s finally block so cleanup happens even when helpers short-circuit
- simplify `writeInputToStream` to only handle normalized writes and log failures without managing stream shutdown
- keep stdin handling coverage ensuring attach options, normalized writes, and graceful cleanup under error conditions

## Testing
- node ./node_modules/jest/bin/jest.js --runTestsByPath tests/runner.stdin.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e13f0045a08332a0afc80ba5eaa367