### PR TITLE
fix: restore container stdin handling

### DIFF
--- a/code-execution-backend/src/services/dockerService.js
+++ b/code-execution-backend/src/services/dockerService.js
@@ -1,5 +1,4 @@
 const Docker = require('dockerode');
-const { PassThrough } = require('stream');
 const { v4: uuidv4 } = require('uuid');
 const logger = require('../utils/logger');
 
@@ -435,128 +434,17 @@ class DockerService {
     let output = '';
     let error = '';
     let exitCode = 0;
+    let timeoutId = null;
     let stdinStream = null;
+    let stdinClosed = false;
 
-    if (typeof container.attach === 'function') {
-      try {
-        stdinStream = await container.attach({
-          stream: true,
-          stdin: true,
-          stdout: true,
-          stderr: true,
-          tty: false
-        });
-      } catch (attachError) {
-        logger.warn(
-          `Failed to attach to container stdin: ${attachError.message}`
-        );
-      }
-    }
-
-    try {
-      stream = await container.attach({
-        stream: true,
-        stdin: true,
-        stdout: true,
-        stderr: true
-      });
-
-      streamEndPromise = new Promise((resolve) => {
-        let resolved = false;
-        const finish = () => {
-          if (!resolved) {
-            resolved = true;
-            resolve();
-          }
-        };
-        stream.on('end', finish);
-        stream.on('close', finish);
-        stream.on('error', finish);
-      });
-
-      stdoutEndPromise = new Promise((resolve) => {
-        let resolved = false;
-        const finish = () => {
-          if (!resolved) {
-            resolved = true;
-            resolve();
-          }
-        };
-        stdoutStream.on('end', finish);
-        stdoutStream.on('close', finish);
-        stdoutStream.on('error', finish);
-      });
-
-      stderrEndPromise = new Promise((resolve) => {
-        let resolved = false;
-        const finish = () => {
-          if (!resolved) {
-            resolved = true;
-            resolve();
-          }
-        };
-        stderrStream.on('end', finish);
-        stderrStream.on('close', finish);
-        stderrStream.on('error', finish);
-      });
-
-      this.docker.modem.demuxStream(stream, stdoutStream, stderrStream);
-
-      await container.start();
-
-      const stdinPayload = this.normalizeInput(input);
-
-      try {
-        if (stdinPayload.length > 0) {
-          stream.write(stdinPayload);
-        }
-      } finally {
-        stream.end();
+    const closeStdin = () => {
+      if (stdinClosed) {
+        return;
       }
 
-      // Set up timeout promise
-      const timeoutPromise = new Promise((resolve) => {
-        timeoutId = setTimeout(() => {
-          resolve({ timedOut: true });
-        }, languageConfig.timeout);
-      });
-
-      // Wait for container to complete or timeout
-      const resultPromise = container.wait();
-
-      if (stdinStream) {
-        await this.writeInputToStream(stdinStream, input);
-      }
-
-      const result = await Promise.race([resultPromise, timeoutPromise]);
-
-      if (result.timedOut) {
-        try {
-          await container.kill();
-        } catch (e) {
-          logger.warn(`Failed to kill timed out container: ${e.message}`);
-        }
-        await resultPromise.catch(() => {});
-        error = 'Execution timed out';
-        exitCode = 124;
-      } else {
-        exitCode = result.StatusCode || 0;
-      }
-
-      clearTimeout(timeoutId);
-
-      await Promise.all([streamEndPromise, stdoutEndPromise, stderrEndPromise]);
-
-      output = Buffer.concat(stdoutChunks).toString('utf-8');
-      if (!result.timedOut) {
-        error = Buffer.concat(stderrChunks).toString('utf-8');
-      }
-
-    } catch (e) {
-      error = `Container execution error: ${e.message}`;
-      exitCode = 1;
-    } finally {
       if (stdinStream && typeof stdinStream.end === 'function') {
+        stdinClosed = true;
         try {
           stdinStream.end();
         } catch (endError) {
@@ -564,7 +452,80 @@ class DockerService {
             `Failed to close container stdin after run error: ${endError.message}`
           );
         }
+      } else {
+        stdinClosed = true;
       }
+    };
+
+    try {
+      if (typeof container.attach !== 'function') {
+        throw new Error('Container does not support stdin attachment');
+      }
+
+      stdinStream = await container.attach({
+        stream: true,
+        stdin: true,
+        stdout: true,
+        stderr: true,
+        tty: false
+      });
+
+      await container.start();
+
+      try {
+        await this.writeInputToStream(stdinStream, input);
+      } finally {
+        closeStdin();
+      }
+
+      const timeoutPromise = new Promise((resolve) => {
+        timeoutId = setTimeout(() => {
+          resolve({ timedOut: true });
+        }, languageConfig.timeout);
+      });
+
+      const waitPromise = container.wait();
+      const result = await Promise.race([waitPromise, timeoutPromise]);
+
+      if (result && result.timedOut) {
+        try {
+          await container.kill();
+        } catch (killError) {
+          logger.warn(`Failed to kill timed out container: ${killError.message}`);
+        }
+
+        await waitPromise.catch(() => {});
+        error = 'Execution timed out';
+        exitCode = 124;
+      } else {
+        exitCode = result?.StatusCode ?? 0;
+
+        let logsBuffer = await container.logs({
+          stdout: true,
+          stderr: true,
+          follow: false
+        });
+
+        if (!logsBuffer) {
+          logsBuffer = Buffer.alloc(0);
+        } else if (Array.isArray(logsBuffer)) {
+          logsBuffer = Buffer.concat(logsBuffer);
+        } else if (!(logsBuffer instanceof Buffer)) {
+          logsBuffer = Buffer.from(String(logsBuffer));
+        }
+
+        const { stdout, stderr } = this.parseDockerStream(logsBuffer);
+        output = stdout;
+        error = stderr;
+      }
+    } catch (e) {
+      error = `Container execution error: ${e.message}`;
+      exitCode = 1;
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      closeStdin();
     }
 
     const executionTime = Date.now() - startTime;


### PR DESCRIPTION
## Summary
- ensure `DockerService.runContainer` attaches stdin once and writes normalized input
- close stdin deterministically and capture logs via `parseDockerStream`
- handle timeout cleanup while keeping container output parsing intact

## Testing
- npm test -- --runTestsByPath tests/runner.stdin.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e14fa77b488332bd71f721f5293871