### PR TITLE
fix: link project settings action

### DIFF
--- a/components/project-actions.tsx
+++ b/components/project-actions.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Play, Save, Share2, Settings, Download, MoreVertical } from "lucide-react";
+import Link from "next/link";
 import ProjectSharingModal from "./project-sharing-modal";
 import ProjectExportModal from "./project-export-modal";
 
@@ -61,10 +62,23 @@ export default function ProjectActions({
               Export Project
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem>
-              <Settings className="h-4 w-4 mr-2" />
-              Project Settings
-            </DropdownMenuItem>
+            {projectId ? (
+              <DropdownMenuItem asChild>
+                <Link
+                  href={`/project/${projectId}/settings`}
+                  className="flex w-full items-center"
+                  prefetch
+                >
+                  <Settings className="h-4 w-4 mr-2" />
+                  Project Settings
+                </Link>
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem disabled>
+                <Settings className="h-4 w-4 mr-2" />
+                Project Settings
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>


### PR DESCRIPTION
## Summary
- add a Next.js Link for the Project Settings menu entry so it matches the dashboard behavior
- disable the menu item when there is no project id available to prevent broken navigation

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*

## Affected Routes
- `/project/[id]`


------
https://chatgpt.com/codex/tasks/task_e_68e154ba3570833293be0a1f57ec3b0b