### PR TITLE
feat: add socket chat fallbacks

### DIFF
--- a/components/project-workspace.tsx
+++ b/components/project-workspace.tsx
@@ -3029,6 +3029,7 @@ export default function ProjectWorkspace({
                 {/* Chat Panel Component */}
                 <div className="flex-1 min-h-0">
                   <ChatPanel
+                    projectId={projectId}
                     conversationId={conversationId}
                     initialMessages={initialChatMessages}
                     teamMembers={teamMembers}

--- a/lib/socket.tsx
+++ b/lib/socket.tsx
@@ -42,6 +42,11 @@ interface SocketContextType {
     result: any;
     userId: string;
   }) => void;
+  emitChatMessage: (data: {
+    projectId: string;
+    conversationId?: string | null;
+    message: Record<string, unknown>;
+  }) => void;
   startTerminalSession: (data: TerminalSocketEvents["terminal:start"]) => void;
   sendTerminalInput: (data: TerminalSocketEvents["terminal:input"]) => void;
   stopTerminalSession: (data: TerminalSocketEvents["terminal:stop"]) => void;
@@ -67,6 +72,7 @@ const SocketContext = createContext<SocketContextType>({
   emitCursorPosition: () => {},
   emitFileSelect: () => {},
   emitExecutionResult: () => {},
+  emitChatMessage: () => {},
   startTerminalSession: () => {},
   sendTerminalInput: () => {},
   stopTerminalSession: () => {},
@@ -303,6 +309,19 @@ export const SocketProvider = ({ children }: SocketProviderProps) => {
     [socket]
   );
 
+  const emitChatMessage = useCallback(
+    (data: {
+      projectId: string;
+      conversationId?: string | null;
+      message: Record<string, unknown>;
+    }) => {
+      if (socket) {
+        socket.emit("chat:message", data);
+      }
+    },
+    [socket]
+  );
+
   const startTerminalSession = useCallback(
     (data: TerminalSocketEvents["terminal:start"]) => {
       emitTerminalEvent("terminal:start", data);
@@ -349,6 +368,7 @@ export const SocketProvider = ({ children }: SocketProviderProps) => {
         emitCursorPosition,
         emitFileSelect,
         emitExecutionResult,
+        emitChatMessage,
         startTerminalSession,
         sendTerminalInput,
         stopTerminalSession,

--- a/server.js
+++ b/server.js
@@ -622,6 +622,24 @@ app.prepare().then(() => {
       })
     })
 
+    socket.on('chat:message', (data = {}) => {
+      const { projectId, conversationId = null, message } = data || {}
+
+      if (!projectId || !message || typeof projectId !== 'string') {
+        return
+      }
+
+      if (collaborators.has(socket.id)) {
+        collaborators.get(socket.id).lastActivity = new Date()
+      }
+
+      socket.to(projectId).emit('chat:message', {
+        projectId,
+        conversationId,
+        message
+      })
+    })
+
     // Handle disconnect
     socket.on('disconnect', () => {
       console.log('User disconnected:', socket.id)


### PR DESCRIPTION
## Summary
- add socket-based chat broadcasting and listeners so project chats update without refreshing
- expose a new emitChatMessage helper on the socket context and forward chat messages through the server
- pass project identifiers into the chat panel to coordinate socket routing while retaining Supabase updates

## Testing
- npm run lint *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68e157a588288332b38fc6ee4bcdf24f