### PR TITLE
fix: respect docker host env

### DIFF
--- a/code-execution-backend/package.json
+++ b/code-execution-backend/package.json
@@ -5,7 +5,7 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "dev": "set DOCKER_HOST=& nodemon src/server.js",
+    "dev": "nodemon src/server.js",
     "test": "jest",
     "docker:build": "node scripts/build-images.js"
   },

--- a/code-execution-backend/src/controllers/executeController.js
+++ b/code-execution-backend/src/controllers/executeController.js
@@ -46,6 +46,11 @@ class ExecuteController {
         requestPayload.stdin = requestPayload.input;
       }
 
+      // Remove legacy aliases before validation so Joi doesn't reject the payload
+      if ('input' in requestPayload) {
+        delete requestPayload.input;
+      }
+
       const { error, value } = executeSchema.validate(requestPayload);
       if (error) {
         return res.status(400).json({

--- a/code-execution-backend/src/server.js
+++ b/code-execution-backend/src/server.js
@@ -1,7 +1,9 @@
 require('dotenv').config();
 
-delete process.env.DOCKER_HOST;                    // kill any injected tcp://localhost:2375
-process.env.DOCKER_SOCKET = '//./pipe/docker_engine'; // optional hint for your builder
+if (!process.env.DOCKER_SOCKET && process.platform === 'win32') {
+  process.env.DOCKER_SOCKET = '//./pipe/docker_engine'; // optional hint for your builder
+}
+
 console.log('DOCKER_HOST in this process =', process.env.DOCKER_HOST || '<unset>');
 
 const express = require('express');


### PR DESCRIPTION
## Summary
- allow custom DOCKER_HOST values to flow through the dev server so Dockerode can connect to remote or tcp sockets
- only provide the Windows pipe hint when no socket is already configured

## Testing
- npm test

## Affected Routes
- /api/execute (Docker-backed execution)

## Related Issues
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68e1645294b083328f62a2cdd57b99a7