### PR TITLE
fix: humanize fallback project titles

### DIFF
--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import CollaboratorsList from "@/components/collaborators-list";
 import { Collaborator, ProjectChatMessageWithAuthor } from "@/lib/types";
 import ProjectActions from "@/components/project-actions";
+import { generateFriendlyProjectName } from "@/lib/utils";
 
 // This type is for your client component, so keep it exported
 export type ProjectNode = {
@@ -261,7 +262,7 @@ export default async function ProjectPage({
         nodesError,
       });
 
-      project = { name: `Project ${params.id}` };
+      project = { name: generateFriendlyProjectName(params.id) };
       nodes = [
         {
           id: "1",
@@ -298,7 +299,7 @@ export default async function ProjectPage({
     console.error("Supabase error:", error);
 
     // Provide mock data as fallback
-    project = { name: `Project ${params.id}` };
+    project = { name: generateFriendlyProjectName(params.id) };
     nodes = [
       {
         id: "1",

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,89 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
+}
+
+const PROJECT_NAME_ADJECTIVES = [
+  "Agile",
+  "Brilliant",
+  "Creative",
+  "Dynamic",
+  "Eager",
+  "Fearless",
+  "Gentle",
+  "Heroic",
+  "Inventive",
+  "Joyful",
+  "Kind",
+  "Lively",
+  "Magnetic",
+  "Nimble",
+  "Optimistic",
+  "Playful",
+  "Quantum",
+  "Radiant",
+  "Spirited",
+  "Tenacious",
+  "Upbeat",
+  "Vivid",
+  "Whimsical",
+  "Youthful",
+  "Zealous",
+];
+
+const PROJECT_NAME_NOUNS = [
+  "Aurora",
+  "Beacon",
+  "Canvas",
+  "Circuit",
+  "Comet",
+  "Engine",
+  "Forge",
+  "Galaxy",
+  "Harbor",
+  "Horizon",
+  "Idea",
+  "Lantern",
+  "Matrix",
+  "Momentum",
+  "Nexus",
+  "Orbit",
+  "Pulse",
+  "Rocket",
+  "Spark",
+  "Studio",
+  "Synth",
+  "Telescope",
+  "Vertex",
+  "Workshop",
+  "Zenith",
+];
+
+function stableHash(input: string): number {
+  let hash = 0;
+  for (let index = 0; index < input.length; index += 1) {
+    hash = (hash << 5) - hash + input.charCodeAt(index);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+export function generateFriendlyProjectName(projectId: string): string {
+  const trimmed = projectId?.trim();
+
+  if (!trimmed) {
+    return "Untitled Project";
+  }
+
+  const hash = stableHash(trimmed);
+  const adjective =
+    PROJECT_NAME_ADJECTIVES[hash % PROJECT_NAME_ADJECTIVES.length];
+  const noun = PROJECT_NAME_NOUNS[(hash >> 8) % PROJECT_NAME_NOUNS.length];
+  const suffix = trimmed.replace(/[^a-zA-Z0-9]/g, "").slice(0, 4).toUpperCase();
+
+  return suffix
+    ? `${adjective} ${noun} ${suffix}`
+    : `${adjective} ${noun}`;
 }


### PR DESCRIPTION
## Summary
- add a deterministic friendly-name generator for project fallbacks
- use the generated name when Supabase lookups fail on the project page

## Testing
- npm run lint *(fails: Failed to load config "next/core-web-vitals" to extend from.)*


------
https://chatgpt.com/codex/tasks/task_e_68e1da21d8b48332bb6fd001736bb1ae